### PR TITLE
feat(store): implement TranscriptStore and TranscriptExporter

### DIFF
--- a/__tests__/store/TranscriptStore.test.ts
+++ b/__tests__/store/TranscriptStore.test.ts
@@ -1,0 +1,274 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests — sozia.client.store
+ *
+ * Scope: TranscriptStore (timeline management) and TranscriptExporter (export formats).
+ *
+ * Test plan reference: TP-CLIENT-STORE-001 through TP-CLIENT-STORE-004
+ */
+
+import { TranscriptStore } from '../../src/store/TranscriptStore';
+import { TranscriptExporter } from '../../src/store/TranscriptExporter';
+import type { TranscriptSegment } from '../../src/common/models';
+import { SegmentStatus, ModalityType } from '../../src/common/models';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let _segCounter = 0;
+
+function makeSegment(overrides: Partial<TranscriptSegment> = {}): TranscriptSegment {
+  const id = `seg-${++_segCounter}`;
+  return {
+    segmentId: id,
+    sessionId: 'session-001',
+    status: SegmentStatus.FINAL,
+    text: 'Merhaba dünya',
+    source: ModalityType.ASR,
+    confidence: 0.85,
+    timestampMs: 1000,
+    durationMs: 500,
+    createdAtMs: Date.now(),
+    replacesSegmentId: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-STORE-001: Basic append and retrieval
+// ---------------------------------------------------------------------------
+
+describe('TranscriptStore — append and retrieval', () => {
+  let store: TranscriptStore;
+
+  beforeEach(() => {
+    store = new TranscriptStore();
+    _segCounter = 0;
+  });
+
+  it('TP-CLIENT-STORE-001a: starts empty', () => {
+    expect(store.getAll()).toEqual([]);
+    expect(store.size).toBe(0);
+  });
+
+  it('TP-CLIENT-STORE-001b: append adds a segment', () => {
+    store.append(makeSegment());
+    expect(store.size).toBe(1);
+  });
+
+  it('TP-CLIENT-STORE-001c: getAll returns a copy, not the internal array', () => {
+    store.append(makeSegment());
+    const first = store.getAll();
+    const second = store.getAll();
+    expect(first).not.toBe(second); // different references
+    expect(first).toEqual(second);  // same contents
+  });
+
+  it('TP-CLIENT-STORE-001d: segments are sorted by timestampMs after append', () => {
+    store.append(makeSegment({ timestampMs: 3000 }));
+    store.append(makeSegment({ timestampMs: 1000 }));
+    store.append(makeSegment({ timestampMs: 2000 }));
+
+    const timestamps = store.getAll().map((s) => s.timestampMs);
+    expect(timestamps).toEqual([1000, 2000, 3000]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-STORE-002: Partial → Final replacement
+// ---------------------------------------------------------------------------
+
+describe('TranscriptStore — partial → final replacement', () => {
+  let store: TranscriptStore;
+
+  beforeEach(() => {
+    store = new TranscriptStore();
+    _segCounter = 0;
+  });
+
+  it('TP-CLIENT-STORE-002a: FINAL segment replaces the referenced PARTIAL in-place', () => {
+    const partial = makeSegment({
+      segmentId: 'partial-1',
+      status: SegmentStatus.PARTIAL,
+      text: 'MERHABA DÜNYA',
+      timestampMs: 1000,
+    });
+    const final = makeSegment({
+      segmentId: 'final-1',
+      status: SegmentStatus.FINAL,
+      text: 'Merhaba dünya',
+      timestampMs: 1000,
+      replacesSegmentId: 'partial-1',
+    });
+
+    store.append(partial);
+    store.append(final);
+
+    expect(store.size).toBe(1);
+    expect(store.getAll()[0].text).toBe('Merhaba dünya');
+    expect(store.getAll()[0].status).toBe(SegmentStatus.FINAL);
+  });
+
+  it('TP-CLIENT-STORE-002b: replacement preserves display order', () => {
+    const p1 = makeSegment({ segmentId: 'p1', status: SegmentStatus.PARTIAL, timestampMs: 1000 });
+    const p2 = makeSegment({ segmentId: 'p2', status: SegmentStatus.PARTIAL, timestampMs: 2000 });
+    const f1 = makeSegment({
+      segmentId: 'f1',
+      status: SegmentStatus.FINAL,
+      timestampMs: 1000,
+      replacesSegmentId: 'p1',
+    });
+
+    store.append(p1);
+    store.append(p2);
+    store.append(f1);
+
+    expect(store.size).toBe(2);
+    expect(store.getAll()[0].segmentId).toBe('f1');
+    expect(store.getAll()[1].segmentId).toBe('p2');
+  });
+
+  it('TP-CLIENT-STORE-002c: FINAL is appended if referenced PARTIAL is not found', () => {
+    const final = makeSegment({
+      segmentId: 'f1',
+      status: SegmentStatus.FINAL,
+      replacesSegmentId: 'nonexistent',
+    });
+
+    store.append(final);
+
+    expect(store.size).toBe(1);
+    expect(store.getAll()[0].segmentId).toBe('f1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-STORE-003: Clear and observer
+// ---------------------------------------------------------------------------
+
+describe('TranscriptStore — clear and onUpdate', () => {
+  let store: TranscriptStore;
+
+  beforeEach(() => {
+    store = new TranscriptStore();
+    _segCounter = 0;
+  });
+
+  it('TP-CLIENT-STORE-003a: clear removes all segments', () => {
+    store.append(makeSegment());
+    store.append(makeSegment());
+    store.clear();
+    expect(store.size).toBe(0);
+  });
+
+  it('TP-CLIENT-STORE-003b: onUpdate fires on append with the current snapshot', () => {
+    const received: TranscriptSegment[][] = [];
+    store.onUpdate((s) => received.push(s));
+
+    store.append(makeSegment());
+    expect(received).toHaveLength(1);
+    expect(received[0]).toHaveLength(1);
+  });
+
+  it('TP-CLIENT-STORE-003c: onUpdate fires on clear with an empty array', () => {
+    store.append(makeSegment());
+    const received: TranscriptSegment[][] = [];
+    store.onUpdate((s) => received.push(s));
+
+    store.clear();
+    expect(received).toHaveLength(1);
+    expect(received[0]).toHaveLength(0);
+  });
+
+  it('TP-CLIENT-STORE-003d: unsubscribe stops update delivery', () => {
+    const received: TranscriptSegment[][] = [];
+    const unsub = store.onUpdate((s) => received.push(s));
+
+    store.append(makeSegment());
+    unsub();
+    store.append(makeSegment());
+
+    expect(received).toHaveLength(1);
+  });
+
+  it('TP-CLIENT-STORE-003e: multiple listeners receive updates simultaneously', () => {
+    const countA = { n: 0 };
+    const countB = { n: 0 };
+    store.onUpdate(() => countA.n++);
+    store.onUpdate(() => countB.n++);
+
+    store.append(makeSegment());
+    expect(countA.n).toBe(1);
+    expect(countB.n).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-STORE-004: TranscriptExporter
+// ---------------------------------------------------------------------------
+
+describe('TranscriptExporter', () => {
+  let store: TranscriptStore;
+  let exporter: TranscriptExporter;
+
+  beforeEach(() => {
+    store = new TranscriptStore();
+    exporter = new TranscriptExporter(store);
+    _segCounter = 0;
+  });
+
+  it('TP-CLIENT-STORE-004a: exportAsText returns empty string when store is empty', () => {
+    expect(exporter.exportAsText()).toBe('');
+  });
+
+  it('TP-CLIENT-STORE-004b: exportAsText includes only FINAL segments', () => {
+    store.append(makeSegment({ segmentId: 'p1', status: SegmentStatus.PARTIAL, text: 'MERHABA' }));
+    store.append(makeSegment({ segmentId: 'f1', status: SegmentStatus.FINAL, text: 'Merhaba' }));
+
+    const text = exporter.exportAsText({ includeTimestamps: false });
+    expect(text).toBe('Merhaba');
+    expect(text).not.toContain('MERHABA');
+  });
+
+  it('TP-CLIENT-STORE-004c: exportAsText includes formatted timestamps by default', () => {
+    store.append(makeSegment({ status: SegmentStatus.FINAL, text: 'Test', timestampMs: 83456 }));
+    const text = exporter.exportAsText();
+    expect(text).toMatch(/^\[01:23\.456\]/);
+  });
+
+  it('TP-CLIENT-STORE-004d: exportAsText omits timestamps when includeTimestamps is false', () => {
+    store.append(makeSegment({ status: SegmentStatus.FINAL, text: 'Tamam' }));
+    const text = exporter.exportAsText({ includeTimestamps: false });
+    expect(text).toBe('Tamam');
+    expect(text).not.toContain('[');
+  });
+
+  it('TP-CLIENT-STORE-004e: exportAsJson returns valid JSON containing all segments', () => {
+    const seg = makeSegment({ status: SegmentStatus.FINAL, text: 'Evet' });
+    store.append(seg);
+
+    const json = exporter.exportAsJson();
+    const parsed = JSON.parse(json) as TranscriptSegment[];
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].text).toBe('Evet');
+  });
+
+  it('TP-CLIENT-STORE-004f: exportAsJson includes PARTIAL segments', () => {
+    store.append(makeSegment({ status: SegmentStatus.PARTIAL, text: 'EVET' }));
+    const parsed = JSON.parse(exporter.exportAsJson()) as TranscriptSegment[];
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].status).toBe(SegmentStatus.PARTIAL);
+  });
+
+  it('TP-CLIENT-STORE-004g: exportAsText joins multiple segments with newlines', () => {
+    store.append(makeSegment({ status: SegmentStatus.FINAL, text: 'Birinci', timestampMs: 1000 }));
+    store.append(makeSegment({ status: SegmentStatus.FINAL, text: 'İkinci', timestampMs: 2000 }));
+
+    const text = exporter.exportAsText({ includeTimestamps: false });
+    expect(text).toBe('Birinci\nİkinci');
+  });
+});

--- a/src/store/TranscriptExporter.ts
+++ b/src/store/TranscriptExporter.ts
@@ -1,0 +1,92 @@
+import type { TranscriptSegment } from '../common/models';
+import type { TranscriptStore } from './TranscriptStore';
+
+/** Plain-text export options. */
+export interface TextExportOptions {
+  /**
+   * If true, each line is prefixed with a `[mm:ss.ms]` timestamp.
+   * Defaults to true.
+   */
+  includeTimestamps?: boolean;
+}
+
+/**
+ * Exports the contents of a {@link TranscriptStore} to portable formats.
+ *
+ * Reads a snapshot from the store at export time — mutations after the call
+ * return do not affect the export output.
+ *
+ * Collaborators: reads from {@link TranscriptStore}.
+ *
+ * Thread/concurrency: stateless and safe to call from any async context.
+ */
+export class TranscriptExporter {
+  private readonly store: TranscriptStore;
+
+  /**
+   * @param store - The transcript store to export from.
+   */
+  constructor(store: TranscriptStore) {
+    this.store = store;
+  }
+
+  /**
+   * Export all FINAL segments as a plain-text string, one segment per line.
+   * PARTIAL segments are excluded — only committed, fused text is exported.
+   *
+   * @param options - Optional formatting controls.
+   * @returns UTF-8 plain text. Empty string if no FINAL segments exist.
+   *
+   * @example
+   * const text = exporter.exportAsText({ includeTimestamps: true });
+   * // "[00:01.320] Merhaba, nasılsın?\n[00:03.750] İyiyim, teşekkür ederim."
+   */
+  exportAsText(options: TextExportOptions = {}): string {
+    const { includeTimestamps = true } = options;
+    const finals = this._finalSegments();
+
+    return finals
+      .map((s) => {
+        if (includeTimestamps) {
+          return `[${TranscriptExporter._formatTimestamp(s.timestampMs)}] ${s.text}`;
+        }
+        return s.text;
+      })
+      .join('\n');
+  }
+
+  /**
+   * Export all segments (PARTIAL and FINAL) as a JSON string.
+   * Includes all metadata fields, suitable for debugging or archival.
+   *
+   * @returns JSON string containing an array of {@link TranscriptSegment} objects.
+   *
+   * @example
+   * const json = exporter.exportAsJson();
+   * // '[{"segmentId":"...","status":"FINAL","text":"Merhaba",...}]'
+   */
+  exportAsJson(): string {
+    return JSON.stringify(this.store.getAll(), null, 2);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private _finalSegments(): TranscriptSegment[] {
+    return this.store.getAll().filter((s) => s.status === 'FINAL');
+  }
+
+  /**
+   * Formats a session-relative millisecond timestamp as `mm:ss.ms`.
+   * @param ms - Milliseconds since session start.
+   * @returns Formatted string, e.g. `"01:23.456"`.
+   */
+  private static _formatTimestamp(ms: number): string {
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    const millis = ms % 1000;
+    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}.${String(millis).padStart(3, '0')}`;
+  }
+}

--- a/src/store/TranscriptStore.ts
+++ b/src/store/TranscriptStore.ts
@@ -1,0 +1,94 @@
+import type { TranscriptSegment } from '../common/models';
+
+/**
+ * Observable in-memory transcript timeline for the active session.
+ *
+ * Maintains an ordered list of {@link TranscriptSegment} objects sorted by
+ * `timestampMs`. Handles the optimistic-then-revise pattern: when a FINAL
+ * segment arrives with a non-null `replacesSegmentId`, the referenced PARTIAL
+ * segment is replaced in-place (preserving display order); if the PARTIAL is
+ * not found, the FINAL is appended as a new entry.
+ *
+ * Collaborators: {@link TranscriptExporter} reads snapshots from this store.
+ * The UI `TranscriptView` subscribes via {@link onUpdate} to re-render on
+ * every change.
+ *
+ * Thread/concurrency: JavaScript single-threaded — all mutations are
+ * synchronous and safe to call from any async context.
+ */
+export class TranscriptStore {
+  private segments: TranscriptSegment[] = [];
+  private listeners = new Set<(segments: TranscriptSegment[]) => void>();
+
+  /**
+   * Add a new segment to the timeline.
+   *
+   * If `segment.replacesSegmentId` is non-null, the store first attempts to
+   * replace the referenced segment in-place. If the referenced segment is not
+   * found (e.g., already cleared), the segment is appended at the end.
+   *
+   * The timeline is kept sorted by `timestampMs` after every append.
+   *
+   * @param segment - The transcript segment to add or use as a replacement.
+   */
+  append(segment: TranscriptSegment): void {
+    if (segment.replacesSegmentId !== null) {
+      const idx = this.segments.findIndex(
+        (s) => s.segmentId === segment.replacesSegmentId
+      );
+      if (idx !== -1) {
+        this.segments[idx] = segment;
+        this._notify();
+        return;
+      }
+    }
+
+    this.segments.push(segment);
+    this.segments.sort((a, b) => a.timestampMs - b.timestampMs);
+    this._notify();
+  }
+
+  /**
+   * Remove all segments from the timeline.
+   * Typically called when the user triggers a manual clear or a new session starts.
+   */
+  clear(): void {
+    this.segments = [];
+    this._notify();
+  }
+
+  /**
+   * Returns a shallow copy of the current segment list, ordered by `timestampMs`.
+   * Safe to iterate without holding a lock.
+   *
+   * @returns Ordered array of transcript segments.
+   */
+  getAll(): TranscriptSegment[] {
+    return [...this.segments];
+  }
+
+  /**
+   * Returns the number of segments currently in the timeline.
+   */
+  get size(): number {
+    return this.segments.length;
+  }
+
+  /**
+   * Register a callback that fires whenever the timeline changes (append or clear).
+   * Returns an unsubscribe function; call it to stop receiving updates.
+   * Multiple listeners may be registered simultaneously.
+   *
+   * @param callback - Receives the full ordered segment list on every change.
+   * @returns Unsubscribe function.
+   */
+  onUpdate(callback: (segments: TranscriptSegment[]) => void): () => void {
+    this.listeners.add(callback);
+    return () => this.listeners.delete(callback);
+  }
+
+  private _notify(): void {
+    const snapshot = this.getAll();
+    this.listeners.forEach((cb) => cb(snapshot));
+  }
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,3 @@
+export { TranscriptStore } from './TranscriptStore';
+export { TranscriptExporter } from './TranscriptExporter';
+export type { TextExportOptions } from './TranscriptExporter';


### PR DESCRIPTION
## What does this PR do?

Implements `sozia.client.store` — the in-memory transcript timeline and export functionality.

**TranscriptStore:**
- `append()` — adds segments, handles PARTIAL→FINAL replacement via `replacesSegmentId` (LLD invariant: appends FINAL if referenced PARTIAL not found)
- `clear()` — wipes the timeline
- `onUpdate()` — observer pattern, multiple subscribers, returns unsubscribe function
- Timeline kept sorted by `timestampMs`

**TranscriptExporter:**
- `exportAsText()` — FINAL segments only, optional `[mm:ss.ms]` timestamps
- `exportAsJson()` — full snapshot of all segments

## Which package(s) does it touch?

`sozia.client.store` — `src/store/`

## How to test

```bash
npx jest --testPathPatterns="TranscriptStore"
```

19 unit tests across TP-CLIENT-STORE-001–004, all passing.

## Checklist
- [x] Follows commit convention (`feat(store): ...`)
- [x] Added/updated tests (19 tests, all passing)
- [x] No sozia.common schema changes
- [x] Tested locally

Closes #8