### PR TITLE
feat(ui): wire LiveTranslationScreen to TranscriptStore

### DIFF
--- a/__tests__/store/TranscriptStore.test.ts
+++ b/__tests__/store/TranscriptStore.test.ts
@@ -1,0 +1,274 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests — sozia.client.store
+ *
+ * Scope: TranscriptStore (timeline management) and TranscriptExporter (export formats).
+ *
+ * Test plan reference: TP-CLIENT-STORE-001 through TP-CLIENT-STORE-004
+ */
+
+import { TranscriptStore } from '../../src/store/TranscriptStore';
+import { TranscriptExporter } from '../../src/store/TranscriptExporter';
+import type { TranscriptSegment } from '../../src/common/models';
+import { SegmentStatus, ModalityType } from '../../src/common/models';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let _segCounter = 0;
+
+function makeSegment(overrides: Partial<TranscriptSegment> = {}): TranscriptSegment {
+  const id = `seg-${++_segCounter}`;
+  return {
+    segmentId: id,
+    sessionId: 'session-001',
+    status: SegmentStatus.FINAL,
+    text: 'Merhaba dünya',
+    source: ModalityType.ASR,
+    confidence: 0.85,
+    timestampMs: 1000,
+    durationMs: 500,
+    createdAtMs: Date.now(),
+    replacesSegmentId: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-STORE-001: Basic append and retrieval
+// ---------------------------------------------------------------------------
+
+describe('TranscriptStore — append and retrieval', () => {
+  let store: TranscriptStore;
+
+  beforeEach(() => {
+    store = new TranscriptStore();
+    _segCounter = 0;
+  });
+
+  it('TP-CLIENT-STORE-001a: starts empty', () => {
+    expect(store.getAll()).toEqual([]);
+    expect(store.size).toBe(0);
+  });
+
+  it('TP-CLIENT-STORE-001b: append adds a segment', () => {
+    store.append(makeSegment());
+    expect(store.size).toBe(1);
+  });
+
+  it('TP-CLIENT-STORE-001c: getAll returns a copy, not the internal array', () => {
+    store.append(makeSegment());
+    const first = store.getAll();
+    const second = store.getAll();
+    expect(first).not.toBe(second); // different references
+    expect(first).toEqual(second);  // same contents
+  });
+
+  it('TP-CLIENT-STORE-001d: segments are sorted by timestampMs after append', () => {
+    store.append(makeSegment({ timestampMs: 3000 }));
+    store.append(makeSegment({ timestampMs: 1000 }));
+    store.append(makeSegment({ timestampMs: 2000 }));
+
+    const timestamps = store.getAll().map((s) => s.timestampMs);
+    expect(timestamps).toEqual([1000, 2000, 3000]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-STORE-002: Partial → Final replacement
+// ---------------------------------------------------------------------------
+
+describe('TranscriptStore — partial → final replacement', () => {
+  let store: TranscriptStore;
+
+  beforeEach(() => {
+    store = new TranscriptStore();
+    _segCounter = 0;
+  });
+
+  it('TP-CLIENT-STORE-002a: FINAL segment replaces the referenced PARTIAL in-place', () => {
+    const partial = makeSegment({
+      segmentId: 'partial-1',
+      status: SegmentStatus.PARTIAL,
+      text: 'MERHABA DÜNYA',
+      timestampMs: 1000,
+    });
+    const final = makeSegment({
+      segmentId: 'final-1',
+      status: SegmentStatus.FINAL,
+      text: 'Merhaba dünya',
+      timestampMs: 1000,
+      replacesSegmentId: 'partial-1',
+    });
+
+    store.append(partial);
+    store.append(final);
+
+    expect(store.size).toBe(1);
+    expect(store.getAll()[0].text).toBe('Merhaba dünya');
+    expect(store.getAll()[0].status).toBe(SegmentStatus.FINAL);
+  });
+
+  it('TP-CLIENT-STORE-002b: replacement preserves display order', () => {
+    const p1 = makeSegment({ segmentId: 'p1', status: SegmentStatus.PARTIAL, timestampMs: 1000 });
+    const p2 = makeSegment({ segmentId: 'p2', status: SegmentStatus.PARTIAL, timestampMs: 2000 });
+    const f1 = makeSegment({
+      segmentId: 'f1',
+      status: SegmentStatus.FINAL,
+      timestampMs: 1000,
+      replacesSegmentId: 'p1',
+    });
+
+    store.append(p1);
+    store.append(p2);
+    store.append(f1);
+
+    expect(store.size).toBe(2);
+    expect(store.getAll()[0].segmentId).toBe('f1');
+    expect(store.getAll()[1].segmentId).toBe('p2');
+  });
+
+  it('TP-CLIENT-STORE-002c: FINAL is appended if referenced PARTIAL is not found', () => {
+    const final = makeSegment({
+      segmentId: 'f1',
+      status: SegmentStatus.FINAL,
+      replacesSegmentId: 'nonexistent',
+    });
+
+    store.append(final);
+
+    expect(store.size).toBe(1);
+    expect(store.getAll()[0].segmentId).toBe('f1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-STORE-003: Clear and observer
+// ---------------------------------------------------------------------------
+
+describe('TranscriptStore — clear and onUpdate', () => {
+  let store: TranscriptStore;
+
+  beforeEach(() => {
+    store = new TranscriptStore();
+    _segCounter = 0;
+  });
+
+  it('TP-CLIENT-STORE-003a: clear removes all segments', () => {
+    store.append(makeSegment());
+    store.append(makeSegment());
+    store.clear();
+    expect(store.size).toBe(0);
+  });
+
+  it('TP-CLIENT-STORE-003b: onUpdate fires on append with the current snapshot', () => {
+    const received: TranscriptSegment[][] = [];
+    store.onUpdate((s) => received.push(s));
+
+    store.append(makeSegment());
+    expect(received).toHaveLength(1);
+    expect(received[0]).toHaveLength(1);
+  });
+
+  it('TP-CLIENT-STORE-003c: onUpdate fires on clear with an empty array', () => {
+    store.append(makeSegment());
+    const received: TranscriptSegment[][] = [];
+    store.onUpdate((s) => received.push(s));
+
+    store.clear();
+    expect(received).toHaveLength(1);
+    expect(received[0]).toHaveLength(0);
+  });
+
+  it('TP-CLIENT-STORE-003d: unsubscribe stops update delivery', () => {
+    const received: TranscriptSegment[][] = [];
+    const unsub = store.onUpdate((s) => received.push(s));
+
+    store.append(makeSegment());
+    unsub();
+    store.append(makeSegment());
+
+    expect(received).toHaveLength(1);
+  });
+
+  it('TP-CLIENT-STORE-003e: multiple listeners receive updates simultaneously', () => {
+    const countA = { n: 0 };
+    const countB = { n: 0 };
+    store.onUpdate(() => countA.n++);
+    store.onUpdate(() => countB.n++);
+
+    store.append(makeSegment());
+    expect(countA.n).toBe(1);
+    expect(countB.n).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-STORE-004: TranscriptExporter
+// ---------------------------------------------------------------------------
+
+describe('TranscriptExporter', () => {
+  let store: TranscriptStore;
+  let exporter: TranscriptExporter;
+
+  beforeEach(() => {
+    store = new TranscriptStore();
+    exporter = new TranscriptExporter(store);
+    _segCounter = 0;
+  });
+
+  it('TP-CLIENT-STORE-004a: exportAsText returns empty string when store is empty', () => {
+    expect(exporter.exportAsText()).toBe('');
+  });
+
+  it('TP-CLIENT-STORE-004b: exportAsText includes only FINAL segments', () => {
+    store.append(makeSegment({ segmentId: 'p1', status: SegmentStatus.PARTIAL, text: 'MERHABA' }));
+    store.append(makeSegment({ segmentId: 'f1', status: SegmentStatus.FINAL, text: 'Merhaba' }));
+
+    const text = exporter.exportAsText({ includeTimestamps: false });
+    expect(text).toBe('Merhaba');
+    expect(text).not.toContain('MERHABA');
+  });
+
+  it('TP-CLIENT-STORE-004c: exportAsText includes formatted timestamps by default', () => {
+    store.append(makeSegment({ status: SegmentStatus.FINAL, text: 'Test', timestampMs: 83456 }));
+    const text = exporter.exportAsText();
+    expect(text).toMatch(/^\[01:23\.456\]/);
+  });
+
+  it('TP-CLIENT-STORE-004d: exportAsText omits timestamps when includeTimestamps is false', () => {
+    store.append(makeSegment({ status: SegmentStatus.FINAL, text: 'Tamam' }));
+    const text = exporter.exportAsText({ includeTimestamps: false });
+    expect(text).toBe('Tamam');
+    expect(text).not.toContain('[');
+  });
+
+  it('TP-CLIENT-STORE-004e: exportAsJson returns valid JSON containing all segments', () => {
+    const seg = makeSegment({ status: SegmentStatus.FINAL, text: 'Evet' });
+    store.append(seg);
+
+    const json = exporter.exportAsJson();
+    const parsed = JSON.parse(json) as TranscriptSegment[];
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].text).toBe('Evet');
+  });
+
+  it('TP-CLIENT-STORE-004f: exportAsJson includes PARTIAL segments', () => {
+    store.append(makeSegment({ status: SegmentStatus.PARTIAL, text: 'EVET' }));
+    const parsed = JSON.parse(exporter.exportAsJson()) as TranscriptSegment[];
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].status).toBe(SegmentStatus.PARTIAL);
+  });
+
+  it('TP-CLIENT-STORE-004g: exportAsText joins multiple segments with newlines', () => {
+    store.append(makeSegment({ status: SegmentStatus.FINAL, text: 'Birinci', timestampMs: 1000 }));
+    store.append(makeSegment({ status: SegmentStatus.FINAL, text: 'İkinci', timestampMs: 2000 }));
+
+    const text = exporter.exportAsText({ includeTimestamps: false });
+    expect(text).toBe('Birinci\nİkinci');
+  });
+});

--- a/src/store/TranscriptExporter.ts
+++ b/src/store/TranscriptExporter.ts
@@ -1,0 +1,92 @@
+import type { TranscriptSegment } from '../common/models';
+import type { TranscriptStore } from './TranscriptStore';
+
+/** Plain-text export options. */
+export interface TextExportOptions {
+  /**
+   * If true, each line is prefixed with a `[mm:ss.ms]` timestamp.
+   * Defaults to true.
+   */
+  includeTimestamps?: boolean;
+}
+
+/**
+ * Exports the contents of a {@link TranscriptStore} to portable formats.
+ *
+ * Reads a snapshot from the store at export time — mutations after the call
+ * return do not affect the export output.
+ *
+ * Collaborators: reads from {@link TranscriptStore}.
+ *
+ * Thread/concurrency: stateless and safe to call from any async context.
+ */
+export class TranscriptExporter {
+  private readonly store: TranscriptStore;
+
+  /**
+   * @param store - The transcript store to export from.
+   */
+  constructor(store: TranscriptStore) {
+    this.store = store;
+  }
+
+  /**
+   * Export all FINAL segments as a plain-text string, one segment per line.
+   * PARTIAL segments are excluded — only committed, fused text is exported.
+   *
+   * @param options - Optional formatting controls.
+   * @returns UTF-8 plain text. Empty string if no FINAL segments exist.
+   *
+   * @example
+   * const text = exporter.exportAsText({ includeTimestamps: true });
+   * // "[00:01.320] Merhaba, nasılsın?\n[00:03.750] İyiyim, teşekkür ederim."
+   */
+  exportAsText(options: TextExportOptions = {}): string {
+    const { includeTimestamps = true } = options;
+    const finals = this._finalSegments();
+
+    return finals
+      .map((s) => {
+        if (includeTimestamps) {
+          return `[${TranscriptExporter._formatTimestamp(s.timestampMs)}] ${s.text}`;
+        }
+        return s.text;
+      })
+      .join('\n');
+  }
+
+  /**
+   * Export all segments (PARTIAL and FINAL) as a JSON string.
+   * Includes all metadata fields, suitable for debugging or archival.
+   *
+   * @returns JSON string containing an array of {@link TranscriptSegment} objects.
+   *
+   * @example
+   * const json = exporter.exportAsJson();
+   * // '[{"segmentId":"...","status":"FINAL","text":"Merhaba",...}]'
+   */
+  exportAsJson(): string {
+    return JSON.stringify(this.store.getAll(), null, 2);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private _finalSegments(): TranscriptSegment[] {
+    return this.store.getAll().filter((s) => s.status === 'FINAL');
+  }
+
+  /**
+   * Formats a session-relative millisecond timestamp as `mm:ss.ms`.
+   * @param ms - Milliseconds since session start.
+   * @returns Formatted string, e.g. `"01:23.456"`.
+   */
+  private static _formatTimestamp(ms: number): string {
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    const millis = ms % 1000;
+    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}.${String(millis).padStart(3, '0')}`;
+  }
+}

--- a/src/store/TranscriptStore.ts
+++ b/src/store/TranscriptStore.ts
@@ -1,0 +1,94 @@
+import type { TranscriptSegment } from '../common/models';
+
+/**
+ * Observable in-memory transcript timeline for the active session.
+ *
+ * Maintains an ordered list of {@link TranscriptSegment} objects sorted by
+ * `timestampMs`. Handles the optimistic-then-revise pattern: when a FINAL
+ * segment arrives with a non-null `replacesSegmentId`, the referenced PARTIAL
+ * segment is replaced in-place (preserving display order); if the PARTIAL is
+ * not found, the FINAL is appended as a new entry.
+ *
+ * Collaborators: {@link TranscriptExporter} reads snapshots from this store.
+ * The UI `TranscriptView` subscribes via {@link onUpdate} to re-render on
+ * every change.
+ *
+ * Thread/concurrency: JavaScript single-threaded — all mutations are
+ * synchronous and safe to call from any async context.
+ */
+export class TranscriptStore {
+  private segments: TranscriptSegment[] = [];
+  private listeners = new Set<(segments: TranscriptSegment[]) => void>();
+
+  /**
+   * Add a new segment to the timeline.
+   *
+   * If `segment.replacesSegmentId` is non-null, the store first attempts to
+   * replace the referenced segment in-place. If the referenced segment is not
+   * found (e.g., already cleared), the segment is appended at the end.
+   *
+   * The timeline is kept sorted by `timestampMs` after every append.
+   *
+   * @param segment - The transcript segment to add or use as a replacement.
+   */
+  append(segment: TranscriptSegment): void {
+    if (segment.replacesSegmentId !== null) {
+      const idx = this.segments.findIndex(
+        (s) => s.segmentId === segment.replacesSegmentId
+      );
+      if (idx !== -1) {
+        this.segments[idx] = segment;
+        this._notify();
+        return;
+      }
+    }
+
+    this.segments.push(segment);
+    this.segments.sort((a, b) => a.timestampMs - b.timestampMs);
+    this._notify();
+  }
+
+  /**
+   * Remove all segments from the timeline.
+   * Typically called when the user triggers a manual clear or a new session starts.
+   */
+  clear(): void {
+    this.segments = [];
+    this._notify();
+  }
+
+  /**
+   * Returns a shallow copy of the current segment list, ordered by `timestampMs`.
+   * Safe to iterate without holding a lock.
+   *
+   * @returns Ordered array of transcript segments.
+   */
+  getAll(): TranscriptSegment[] {
+    return [...this.segments];
+  }
+
+  /**
+   * Returns the number of segments currently in the timeline.
+   */
+  get size(): number {
+    return this.segments.length;
+  }
+
+  /**
+   * Register a callback that fires whenever the timeline changes (append or clear).
+   * Returns an unsubscribe function; call it to stop receiving updates.
+   * Multiple listeners may be registered simultaneously.
+   *
+   * @param callback - Receives the full ordered segment list on every change.
+   * @returns Unsubscribe function.
+   */
+  onUpdate(callback: (segments: TranscriptSegment[]) => void): () => void {
+    this.listeners.add(callback);
+    return () => this.listeners.delete(callback);
+  }
+
+  private _notify(): void {
+    const snapshot = this.getAll();
+    this.listeners.forEach((cb) => cb(snapshot));
+  }
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,3 @@
+export { TranscriptStore } from './TranscriptStore';
+export { TranscriptExporter } from './TranscriptExporter';
+export type { TextExportOptions } from './TranscriptExporter';

--- a/src/ui/SessionController.tsx
+++ b/src/ui/SessionController.tsx
@@ -1,11 +1,14 @@
 import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
 
 import { ModalityPath, SessionState } from '../common/models';
+import { TranscriptStore } from '../store';
 
 export type SessionControllerValue = {
   sessionId: string | null;
   state: SessionState;
   activePath: ModalityPath | null;
+  /** Shared transcript timeline for the active session. */
+  store: TranscriptStore;
 
   startSession: (path: ModalityPath) => Promise<void>;
   pauseSession: () => void;
@@ -55,6 +58,10 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
   const [state, setState] = useState<SessionState>(SessionState.IDLE);
   const [activePath, setActivePath] = useState<ModalityPath | null>(null);
 
+  // Stable store instance — lives for the lifetime of the provider.
+  // Cleared at the start of each new session and on stop.
+  const store = useMemo(() => new TranscriptStore(), []);
+
   const stateRef = useRef(state);
   stateRef.current = state;
 
@@ -63,6 +70,7 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
   const startSession = useCallback(async (path: ModalityPath) => {
     try {
       setState(SessionState.INITIALIZING);
+      store.clear();
       const newSessionId = uuidV4();
       setSessionId(newSessionId);
       setActivePath(path);
@@ -72,7 +80,7 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
       setState(SessionState.ERROR);
       throw e;
     }
-  }, []);
+  }, [store]);
 
   const pauseSession = useCallback(() => {
     setState((prev) => (prev === SessionState.RUNNING ? SessionState.PAUSED : prev));
@@ -86,20 +94,22 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
     setState(SessionState.IDLE);
     setSessionId(null);
     setActivePath(null);
-  }, []);
+    store.clear();
+  }, [store]);
 
   const value = useMemo<SessionControllerValue>(
     () => ({
       sessionId,
       state,
       activePath,
+      store,
       startSession,
       pauseSession,
       resumeSession,
       stopSession,
       getState,
     }),
-    [activePath, getState, pauseSession, resumeSession, sessionId, startSession, state, stopSession]
+    [activePath, getState, pauseSession, resumeSession, sessionId, startSession, state, stopSession, store]
   );
 
   return <SessionControllerContext.Provider value={value}>{children}</SessionControllerContext.Provider>;

--- a/src/ui/screens/LiveTranslationScreen.tsx
+++ b/src/ui/screens/LiveTranslationScreen.tsx
@@ -1,12 +1,36 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ChevronDown, CircleX, Settings, SwitchCamera } from 'lucide-react-native';
 
+import { ModalityType, SegmentStatus, type TranscriptSegment } from '../../common/models';
 import { useSessionController } from '../SessionController';
 
+// ---------------------------------------------------------------------------
+// DEV-only test data
+// ---------------------------------------------------------------------------
+
+const DEV_LINES = [
+  { partial: 'Merhaba, bugün size nasıl…', final: 'Merhaba, bugün size nasıl yardımcı olabilirim?' },
+  { partial: 'Evet, anlıyorum sizi…', final: 'Evet, sizi anlıyorum. Devam edebilirsiniz.' },
+  { partial: 'Teşekkür ederim…', final: 'Çok teşekkür ederim, iyi günler.' },
+];
+
+let _devIdCounter = 0;
+function devId() { return `dev-${++_devIdCounter}`; }
+
+// ---------------------------------------------------------------------------
+
 export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
-  const { state, sessionId, activePath, stopSession } = useSessionController();
+  const { state, sessionId, activePath, stopSession, store } = useSessionController();
+
+  const [segments, setSegments] = useState<TranscriptSegment[]>([]);
+
+  useEffect(() => {
+    setSegments(store.getAll());
+    const unsub = store.onUpdate((s) => setSegments(s));
+    return unsub;
+  }, [store]);
 
   const [language, setLanguage] = useState<'TR' | 'EN'>('EN');
   const [showSettings, setShowSettings] = useState(false);
@@ -14,6 +38,48 @@ export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
   const [groupMode, setGroupMode] = useState(false);
 
   const baseFontSize = Math.max(24, (textSize / 100) * 30);
+
+  // DEV inject: cycles through lines, partial → final → next line
+  const devStep = useRef<{ lineIdx: number; partialId: string | null }>({ lineIdx: 0, partialId: null });
+
+  function handleDevInject() {
+    const { lineIdx, partialId } = devStep.current;
+    const line = DEV_LINES[lineIdx % DEV_LINES.length];
+    const now = Date.now();
+
+    if (partialId === null) {
+      // Step 1: inject PARTIAL
+      const id = devId();
+      store.append({
+        segmentId: id,
+        sessionId: sessionId ?? 'dev',
+        status: SegmentStatus.PARTIAL,
+        text: line.partial,
+        source: ModalityType.ASR,
+        confidence: 0.72,
+        timestampMs: now,
+        durationMs: 500,
+        createdAtMs: now,
+        replacesSegmentId: null,
+      });
+      devStep.current = { lineIdx, partialId: id };
+    } else {
+      // Step 2: upgrade to FINAL
+      store.append({
+        segmentId: devId(),
+        sessionId: sessionId ?? 'dev',
+        status: SegmentStatus.FINAL,
+        text: line.final,
+        source: ModalityType.ASR,
+        confidence: 0.91,
+        timestampMs: now,
+        durationMs: 800,
+        createdAtMs: now,
+        replacesSegmentId: partialId,
+      });
+      devStep.current = { lineIdx: lineIdx + 1, partialId: null };
+    }
+  }
 
   return (
     <SafeAreaView className="flex-1 w-full self-stretch bg-gradient-to-br from-[#2ECC71]/5 via-white to-[#2ECC71]/5">
@@ -153,6 +219,26 @@ export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
               </View>
             )}
 
+            {/* DEV: inject test segments */}
+            {__DEV__ && (
+              <View className="absolute bottom-44 left-0 right-0 z-40 flex-row items-center justify-center gap-2 px-4">
+                <TouchableOpacity
+                  className="rounded-full bg-yellow-400/90 px-4 py-2"
+                  onPress={handleDevInject}
+                >
+                  <Text className="text-xs font-bold text-black">
+                    {devStep.current.partialId === null ? '+ Partial' : '→ Final'}
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  className="rounded-full bg-white/20 px-4 py-2"
+                  onPress={() => { store.clear(); devStep.current = { lineIdx: 0, partialId: null }; }}
+                >
+                  <Text className="text-xs font-bold text-white">Clear</Text>
+                </TouchableOpacity>
+              </View>
+            )}
+
             {/* Subtitle overlay */}
             <View className="absolute bottom-0 left-0 right-0 z-30 flex-col justify-end pb-6">
               <View className="mx-4 rounded-3xl border-t-2 border-white/20 bg-black/75 px-6 py-8">
@@ -162,14 +248,7 @@ export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
                     <Text className="text-sm font-bold text-[#2ECC71]">Speaker 1</Text>
                   </View>
                 )}
-                <Text
-                  className="text-center font-bold leading-relaxed text-white"
-                  style={{ fontSize: baseFontSize }}
-                >
-                  {language === 'TR'
-                    ? 'Merhaba, bugün size nasıl yardımcı olabilirim?'
-                    : 'Hello, how can I help you today?'}
-                </Text>
+                <TranscriptView segments={segments} baseFontSize={baseFontSize} />
                 <View className="mt-3 items-center">
                   <Text className="text-xs text-gray-400">
                     Session {sessionId ?? '—'} · Path {activePath ?? '—'}
@@ -182,5 +261,59 @@ export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
         </View>
       </ScrollView>
     </SafeAreaView>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TranscriptView
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders the last few transcript segments inside the subtitle overlay.
+ *
+ * Visual contract (LLD Trade-off 3):
+ * - FINAL segments: bold white — committed, fused text.
+ * - PARTIAL segments: italic, muted white — tentative, may be revised.
+ * - Empty timeline: shows a waiting prompt so the user knows the session is live.
+ */
+function TranscriptView({
+  segments,
+  baseFontSize,
+}: {
+  segments: TranscriptSegment[];
+  baseFontSize: number;
+}) {
+  // Show only the last 3 segments to keep the overlay readable.
+  const visible = segments.slice(-3);
+
+  if (visible.length === 0) {
+    return (
+      <Text
+        className="text-center italic leading-relaxed text-white/40"
+        style={{ fontSize: baseFontSize }}
+      >
+        Listening…
+      </Text>
+    );
+  }
+
+  return (
+    <View className="gap-1">
+      {visible.map((seg) => {
+        const isPartial = seg.status === SegmentStatus.PARTIAL;
+        return (
+          <Text
+            key={seg.segmentId}
+            className={[
+              'text-center leading-relaxed',
+              isPartial ? 'italic text-white/50' : 'font-bold text-white',
+            ].join(' ')}
+            style={{ fontSize: baseFontSize }}
+          >
+            {seg.text}
+          </Text>
+        );
+      })}
+    </View>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Connects the transcript store to the UI so real segments render as soon as the server starts pushing them.

**SessionController:**
- Holds a stable `TranscriptStore` instance exposed via context
- `startSession()` and `stopSession()` both call `store.clear()` — each session starts with a clean timeline

**LiveTranslationScreen:**
- Subscribes to `store.onUpdate()` via `useEffect`
- Renders last 3 segments through a new `TranscriptView` component
- Visual contract (LLD Trade-off 3): FINAL = bold white, PARTIAL = italic muted white, empty = "Listening…"
- `__DEV__`-only inject buttons (`+ Partial` / `→ Final` / `Clear`) for manual testing without a server

## Which package(s) does it touch?

`sozia.client.ui` — `src/ui/`

## How to test

Run the app, navigate to Live Translation. Verify:
1. Subtitle overlay shows "Listening…" on empty store
2. Tap `+ Partial` — italic muted text appears
3. Tap `→ Final` — text updates to bold white in-place
4. Stop session — store clears, next session starts fresh

## Checklist
- [x] Follows commit convention (`feat(ui): ...`)
- [x] Added/updated tests (store tests cherry-picked onto branch, 19 passing)
- [x] No sozia.common schema changes
- [x] Tested locally

Closes #9