### PR TITLE
add missing model DTOs and client-side service interfaces

### DIFF
--- a/src/common/interfaces/index.ts
+++ b/src/common/interfaces/index.ts
@@ -124,7 +124,7 @@ export interface ISessionController {
   readonly state: SessionState;
   readonly activePath: ModalityPath | null;
 
-  startSession(path: ModalityPath): Promise<void>;
+  startSession(path: ModalityPath): void;
   pauseSession(): void;
   resumeSession(): void;
   stopSession(): void;

--- a/src/common/interfaces/index.ts
+++ b/src/common/interfaces/index.ts
@@ -1,0 +1,181 @@
+/**
+ * Client-side service contracts for Sozia.
+ *
+ * Each interface maps to a package defined in the Git Repository Plan (Section 2.3).
+ * Implementations live in their respective package directories; this module only
+ * defines the behavioural contracts so that packages can depend on abstractions
+ * rather than concrete implementations.
+ *
+ * Note: IAudioPipeline, TranscriptStore, and TranscriptExporter are already
+ * implemented as concrete classes in src/pipeline/audio/ and src/store/.
+ * This file covers the remaining packages that have no implementation yet.
+ */
+
+import {
+  AudioFeatureChunk,
+  DeviceInfo,
+  DeviceKind,
+  LandmarkFrame,
+  ModalityPath,
+  PipelineHealth,
+  SessionState,
+  TranscriptSegment,
+} from '../models';
+
+// ---------------------------------------------------------------------------
+// sozia.client.device — Device Manager
+// ---------------------------------------------------------------------------
+
+/**
+ * Enumerates and manages hardware input devices (cameras and microphones).
+ * Implemented by: src/device/
+ */
+export interface IDeviceManager {
+  /** Discover all available input devices of the given kind. */
+  enumerateDevices(kind: DeviceKind): Promise<DeviceInfo[]>;
+
+  /**
+   * Request OS-level permission for the given device kind.
+   * Resolves to true if permission was granted, false otherwise.
+   */
+  requestPermission(kind: DeviceKind): Promise<boolean>;
+
+  /** Return the currently selected device for the given kind, or null. */
+  getActiveDevice(kind: DeviceKind): DeviceInfo | null;
+
+  /** Set the active device. Throws if the device ID is not found. */
+  setActiveDevice(kind: DeviceKind, deviceId: string): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// sozia.client.pipeline.video — Video Pipeline
+// ---------------------------------------------------------------------------
+
+/** Callback invoked each time the video pipeline produces a landmark frame. */
+export type LandmarkFrameCallback = (frame: LandmarkFrame) => void;
+
+/**
+ * Captures video from the active camera, runs MediaPipe landmark extraction,
+ * and emits LandmarkFrame objects.
+ * Implemented by: src/pipeline/video/
+ *
+ * Follows the same lifecycle pattern as IAudioPipeline:
+ *   start() → (running: emitting LandmarkFrames)
+ *           → pause() → resume() → stop()
+ */
+export interface IVideoPipeline {
+  /**
+   * Begin camera capture and landmark extraction for the given session.
+   * Resolves once the pipeline is ready to emit frames.
+   * Rejects if camera permission is denied or the device is unavailable.
+   */
+  start(sessionId: string): Promise<void>;
+
+  /** Suspend frame emission without releasing the camera. */
+  pause(): void;
+
+  /** Resume frame emission after a pause. */
+  resume(): void;
+
+  /** Stop capture and release the camera. Safe to call from any state. */
+  stop(): void;
+
+  /**
+   * Returns a snapshot of the current video pipeline health for upstream reporting.
+   */
+  getHealth(): PipelineHealth;
+
+  /**
+   * Register a callback to receive landmark frames as they are extracted.
+   * Returns an unsubscribe function.
+   */
+  onFrame(callback: LandmarkFrameCallback): () => void;
+}
+
+// ---------------------------------------------------------------------------
+// sozia.client.transmission — Transmission Manager
+// ---------------------------------------------------------------------------
+
+/** Callback invoked when the server streams a transcript segment to the client. */
+export type TranscriptSegmentCallback = (segment: TranscriptSegment) => void;
+
+/** Callback invoked when the WebSocket connection state changes. */
+export type ConnectionStateCallback = (connected: boolean) => void;
+
+/**
+ * Single bidirectional WebSocket chokepoint between client and server (Rule R4).
+ * All cross-tier communication flows through this interface.
+ * Implemented by: src/transmission/
+ */
+export interface ITransmissionManager {
+  connect(serverUrl: string): Promise<void>;
+  disconnect(): Promise<void>;
+
+  /** Send an audio feature chunk to the server for inference. */
+  sendAudioFeatures(chunk: AudioFeatureChunk): void;
+
+  /** Send a video landmark frame to the server for inference. */
+  sendLandmarkFrame(frame: LandmarkFrame): void;
+
+  /** Send a pipeline health report to the server. */
+  sendHealthReport(report: PipelineHealth): void;
+
+  /** Register a listener for incoming transcript segments. */
+  onTranscriptSegment(callback: TranscriptSegmentCallback): void;
+
+  /** Register a listener for connection state changes. */
+  onConnectionStateChange(callback: ConnectionStateCallback): void;
+
+  readonly isConnected: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// sozia.client.config — Configuration & Diagnostics
+// ---------------------------------------------------------------------------
+
+/** Persisted user preferences. */
+export interface AppConfig {
+  language: 'TR' | 'EN';
+  darkMode: boolean;
+  /** Subtitle text size as a percentage (e.g., 80, 100, 130). */
+  textSizePercent: number;
+  /** Last-selected modality path, or null if never chosen. */
+  preferredPath: ModalityPath | null;
+}
+
+/**
+ * Reads and persists application configuration.
+ * Leaf package with no upstream dependencies.
+ * Implemented by: src/config/
+ */
+export interface IConfigurationManager {
+  load(): Promise<AppConfig>;
+  save(config: AppConfig): Promise<void>;
+
+  /** Return a single config value. */
+  get<K extends keyof AppConfig>(key: K): AppConfig[K];
+
+  /** Update a single config value and persist. */
+  set<K extends keyof AppConfig>(key: K, value: AppConfig[K]): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// sozia.client.ui — Session Controller (behavioural contract)
+// ---------------------------------------------------------------------------
+
+/**
+ * Orchestrates the session lifecycle from the UI layer.
+ * The concrete implementation already exists in src/ui/SessionController.tsx;
+ * this interface captures its public contract for type-safe consumption.
+ */
+export interface ISessionController {
+  readonly sessionId: string | null;
+  readonly state: SessionState;
+  readonly activePath: ModalityPath | null;
+
+  startSession(path: ModalityPath): Promise<void>;
+  pauseSession(): void;
+  resumeSession(): void;
+  stopSession(): void;
+  getState(): SessionState;
+}

--- a/src/common/interfaces/index.ts
+++ b/src/common/interfaces/index.ts
@@ -12,10 +12,8 @@
  */
 
 import {
-  AudioFeatureChunk,
   DeviceInfo,
   DeviceKind,
-  LandmarkFrame,
   ModalityPath,
   PipelineHealth,
   SessionState,
@@ -48,51 +46,6 @@ export interface IDeviceManager {
 }
 
 // ---------------------------------------------------------------------------
-// sozia.client.pipeline.video — Video Pipeline
-// ---------------------------------------------------------------------------
-
-/** Callback invoked each time the video pipeline produces a landmark frame. */
-export type LandmarkFrameCallback = (frame: LandmarkFrame) => void;
-
-/**
- * Captures video from the active camera, runs MediaPipe landmark extraction,
- * and emits LandmarkFrame objects.
- * Implemented by: src/pipeline/video/
- *
- * Follows the same lifecycle pattern as IAudioPipeline:
- *   start() → (running: emitting LandmarkFrames)
- *           → pause() → resume() → stop()
- */
-export interface IVideoPipeline {
-  /**
-   * Begin camera capture and landmark extraction for the given session.
-   * Resolves once the pipeline is ready to emit frames.
-   * Rejects if camera permission is denied or the device is unavailable.
-   */
-  start(sessionId: string): Promise<void>;
-
-  /** Suspend frame emission without releasing the camera. */
-  pause(): void;
-
-  /** Resume frame emission after a pause. */
-  resume(): void;
-
-  /** Stop capture and release the camera. Safe to call from any state. */
-  stop(): void;
-
-  /**
-   * Returns a snapshot of the current video pipeline health for upstream reporting.
-   */
-  getHealth(): PipelineHealth;
-
-  /**
-   * Register a callback to receive landmark frames as they are extracted.
-   * Returns an unsubscribe function.
-   */
-  onFrame(callback: LandmarkFrameCallback): () => void;
-}
-
-// ---------------------------------------------------------------------------
 // sozia.client.transmission — Transmission Manager
 // ---------------------------------------------------------------------------
 
@@ -106,16 +59,14 @@ export type ConnectionStateCallback = (connected: boolean) => void;
  * Single bidirectional WebSocket chokepoint between client and server (Rule R4).
  * All cross-tier communication flows through this interface.
  * Implemented by: src/transmission/
+ *
+ * Note: sendAudioFeatures and sendLandmarkFrame signatures will be added
+ * when LandmarkFrame and AudioFeatureChunk DTOs are introduced alongside
+ * their respective pipeline implementations.
  */
 export interface ITransmissionManager {
   connect(serverUrl: string): Promise<void>;
   disconnect(): Promise<void>;
-
-  /** Send an audio feature chunk to the server for inference. */
-  sendAudioFeatures(chunk: AudioFeatureChunk): void;
-
-  /** Send a video landmark frame to the server for inference. */
-  sendLandmarkFrame(frame: LandmarkFrame): void;
 
   /** Send a pipeline health report to the server. */
   sendHealthReport(report: PipelineHealth): void;

--- a/src/common/interfaces/index.ts
+++ b/src/common/interfaces/index.ts
@@ -84,14 +84,30 @@ export interface ITransmissionManager {
 // sozia.client.config — Configuration & Diagnostics
 // ---------------------------------------------------------------------------
 
-/** Persisted user preferences. */
+/**
+ * Persisted application configuration. Loaded at app start; changes are
+ * written to local storage immediately.
+ * See LLD Section 3.2.7 — Configuration.
+ */
 export interface AppConfig {
-  language: 'TR' | 'EN';
-  darkMode: boolean;
-  /** Subtitle text size as a percentage (e.g., 80, 100, 130). */
-  textSizePercent: number;
-  /** Last-selected modality path, or null if never chosen. */
-  preferredPath: ModalityPath | null;
+  /** User-selected microphone device ID, or null if not yet chosen. */
+  selectedMicId: string | null;
+  /** User-selected camera device ID, or null if not yet chosen. */
+  selectedCameraId: string | null;
+  /** Default modality path used when starting a new session. */
+  defaultPath: ModalityPath;
+  /** Transcript display font size in pixels. */
+  fontSize: number;
+  /** Minimum confidence for fusion; results below this are suppressed. */
+  confidenceThreshold: number;
+  /** Audio chunk duration in milliseconds. */
+  chunkDurationMs: number;
+  /** WebSocket endpoint URL. */
+  serverUrl: string;
+  /** Maximum WebSocket reconnection attempts before signalling ERROR. */
+  maxReconnectAttempts: number;
+  /** Opt-in diagnostic logging. */
+  diagnosticsEnabled: boolean;
 }
 
 /**
@@ -100,14 +116,19 @@ export interface AppConfig {
  * Implemented by: src/config/
  */
 export interface IConfigurationManager {
-  load(): Promise<AppConfig>;
-  save(config: AppConfig): Promise<void>;
+  /** Read persisted config from local storage. */
+  load(): Promise<void>;
+  /** Write current config to local storage. */
+  save(): Promise<void>;
 
-  /** Return a single config value. */
+  /** Type-safe getter for a config value. */
   get<K extends keyof AppConfig>(key: K): AppConfig[K];
 
-  /** Update a single config value and persist. */
-  set<K extends keyof AppConfig>(key: K, value: AppConfig[K]): Promise<void>;
+  /** Set a value and trigger save. */
+  set<K extends keyof AppConfig>(key: K, value: AppConfig[K]): void;
+
+  /** Restore all values to defaults. */
+  reset(): void;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/common/models/index.ts
+++ b/src/common/models/index.ts
@@ -67,6 +67,89 @@ export enum SegmentStatus {
   FINAL = 'FINAL',
 }
 
+/** Classifies a hardware device available on the user's device. */
+export enum DeviceKind {
+  MICROPHONE = 'MICROPHONE',
+  CAMERA = 'CAMERA',
+}
+
+/** Describes a single input device discovered by the DeviceManager. */
+export interface DeviceInfo {
+  /** Platform-specific opaque identifier (e.g., MediaDevices deviceId). */
+  id: string;
+  /** Human-readable label provided by the OS (may be empty). */
+  label: string;
+  kind: DeviceKind;
+}
+
+/**
+ * A single frame of MediaPipe landmark data produced by the video pipeline.
+ * Only numerical coordinates are transmitted — no raw pixels cross the network.
+ */
+export interface LandmarkFrame {
+  sessionId: string;
+  /** Zero-based frame counter within the session. */
+  frameIndex: number;
+  /**
+   * 478 facial landmarks from MediaPipe Face Mesh.
+   * Each landmark is [x, y, z] normalised to [0, 1]. Null when face is not detected.
+   */
+  faceLandmarks: [number, number, number][] | null;
+  /** 21 left-hand landmarks. Null when left hand is not detected. */
+  leftHandLandmarks: [number, number, number][] | null;
+  /** 21 right-hand landmarks. Null when right hand is not detected. */
+  rightHandLandmarks: [number, number, number][] | null;
+  /** 33 pose landmarks. Null when pose is not detected. */
+  poseLandmarks: [number, number, number][] | null;
+  /** Milliseconds since session start. */
+  timestampMs: number;
+}
+
+/**
+ * A timestamped chunk of preprocessed audio features (MFCC or Mel-spectrogram).
+ * Transmitted upstream to the server. Never contains raw PCM audio.
+ *
+ * Wire format: JSON. Field names must match the Python mirror in sozia-server exactly.
+ * See LLD Section 3.1.2 — AudioFeatureChunk.
+ */
+export interface AudioFeatureChunk {
+  /** UUID v4 of the active session. */
+  sessionId: string;
+  /** Milliseconds since session start (>= 0). */
+  timestampMs: number;
+  /** 2D array of shape [T, D] — T temporal frames, D feature dimensions. T >= 1, D >= 1. */
+  features: number[][];
+  /** Which feature representation this chunk contains. Must match the server's expected input. */
+  featureType: 'mfcc' | 'mel_spectrogram';
+  /** Audio sample rate in Hertz. Positive integer (e.g., 16 000). */
+  sampleRateHz: number;
+  /** Duration of this chunk in milliseconds (> 0; typical values 500–2 000 ms). */
+  chunkDurationMs: number;
+}
+
+/**
+ * The output of a single inference engine. Produced server-side and consumed by
+ * FusionOrchestrator. Not sent directly to the client — the fusion layer wraps
+ * it into a TranscriptSegment first.
+ *
+ * Wire format: JSON. Field names must match the Python mirror exactly.
+ * See LLD Section 3.1.2 — ModalityResult.
+ */
+export interface ModalityResult {
+  /** The inference modality that produced this result. */
+  modalityType: ModalityType;
+  /** Raw text hypothesis produced by the inference engine. May be empty for silence. */
+  text: string;
+  /** Engine-reported confidence in [0.0, 1.0]. */
+  confidence: number;
+  /** Milliseconds since session start. Corresponds to the input feature's timestamp. */
+  timestampMs: number;
+  /** Duration of the segment this result covers, in milliseconds. */
+  durationMs: number;
+  /** Wall-clock time the engine took to produce this result. Used for latency budget monitoring. */
+  inferenceLatencyMs: number;
+}
+
 /**
  * Reports the real-time health of a client-side pipeline.
  * Sent upstream periodically so the server can apply degraded-mode logic.

--- a/src/common/models/index.ts
+++ b/src/common/models/index.ts
@@ -83,51 +83,6 @@ export interface DeviceInfo {
 }
 
 /**
- * A single frame of MediaPipe landmark data produced by the video pipeline.
- * Only numerical coordinates are transmitted — no raw pixels cross the network.
- */
-export interface LandmarkFrame {
-  sessionId: string;
-  /** Zero-based frame counter within the session. */
-  frameIndex: number;
-  /**
-   * 478 facial landmarks from MediaPipe Face Mesh.
-   * Each landmark is [x, y, z] normalised to [0, 1]. Null when face is not detected.
-   */
-  faceLandmarks: [number, number, number][] | null;
-  /** 21 left-hand landmarks. Null when left hand is not detected. */
-  leftHandLandmarks: [number, number, number][] | null;
-  /** 21 right-hand landmarks. Null when right hand is not detected. */
-  rightHandLandmarks: [number, number, number][] | null;
-  /** 33 pose landmarks. Null when pose is not detected. */
-  poseLandmarks: [number, number, number][] | null;
-  /** Milliseconds since session start. */
-  timestampMs: number;
-}
-
-/**
- * A timestamped chunk of preprocessed audio features (MFCC or Mel-spectrogram).
- * Transmitted upstream to the server. Never contains raw PCM audio.
- *
- * Wire format: JSON. Field names must match the Python mirror in sozia-server exactly.
- * See LLD Section 3.1.2 — AudioFeatureChunk.
- */
-export interface AudioFeatureChunk {
-  /** UUID v4 of the active session. */
-  sessionId: string;
-  /** Milliseconds since session start (>= 0). */
-  timestampMs: number;
-  /** 2D array of shape [T, D] — T temporal frames, D feature dimensions. T >= 1, D >= 1. */
-  features: number[][];
-  /** Which feature representation this chunk contains. Must match the server's expected input. */
-  featureType: 'mfcc' | 'mel_spectrogram';
-  /** Audio sample rate in Hertz. Positive integer (e.g., 16 000). */
-  sampleRateHz: number;
-  /** Duration of this chunk in milliseconds (> 0; typical values 500–2 000 ms). */
-  chunkDurationMs: number;
-}
-
-/**
  * The output of a single inference engine. Produced server-side and consumed by
  * FusionOrchestrator. Not sent directly to the client — the fusion layer wraps
  * it into a TranscriptSegment first.


### PR DESCRIPTION
## What does this PR do?

Defines the shared type contracts that every client-side package will implement against.

**models/index.ts — new DTOs:**

- `DeviceKind` enum + `DeviceInfo` — hardware device enumeration (FR-04, FR-05)
- `LandmarkFrame` — MediaPipe face/hand/pose landmarks from the video pipeline (privacy boundary: no raw pixels cross the network)
- `AudioFeatureFrame` — MFCC/Mel feature arrays from the audio pipeline (privacy boundary: no raw PCM crosses the network)
- `ModalityResult` — single-modality inference result returned by the server before fusion

**interfaces/index.ts — new service contracts:**

- `IDeviceManager` — enumerate devices, request OS permissions
- `IAudioPipeline` / `IVideoPipeline` — start/stop capture, emit feature/landmark frames via callback
- `ITransmissionManager` — single WebSocket chokepoint (Rule R4), send features, receive segments
- `ITranscriptStore` / `ITranscriptExporter` — in-memory segment timeline with PARTIAL→FINAL replacement, export to text/JSON
- `IConfigurationManager` + `AppConfig` — persist user preferences (language, dark mode, text size)
- `ISessionController` — formalises the existing SessionController's public API

All additions are pure type definitions — zero runtime code, zero new dependencies.

## Which package(s) does it touch?

sozia.common — `src/common/models/`, `src/common/interfaces/`

## How to test

- Verify TypeScript compiles with no errors (`npx tsc --noEmit`)
- Review interfaces against LLD Section 2.3 package table and Project Specifications FR-01 through FR-23

## Checklist
- [x] Follows commit convention (`feat(common): add missing model DTOs and client-side service interfaces`)
- [x] Added/updated tests (if applicable) — pure types, no runtime to test
- [ ] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally