### PR TITLE
feat(audio-pipeline): wire ExpoAudioPipeline into SessionController and implement AudioChunker

### DIFF
--- a/src/common/models/index.ts
+++ b/src/common/models/index.ts
@@ -91,6 +91,30 @@ export interface PipelineHealth {
 }
 
 /**
+ * A batch of audio feature vectors ready for transmission to the inference server.
+ * Produced by AudioChunker from raw MFCCFrames; sent over WebSocket by TransmissionManager.
+ *
+ * Privacy note: contains only anonymized numerical feature data — no raw audio.
+ */
+export interface AudioFeatureChunk {
+  /** UUID v4 of the active session. */
+  sessionId: string;
+  /** Milliseconds since session start; taken from the first frame in the batch. */
+  timestampMs: number;
+  /**
+   * Array of feature vectors — one per captured frame.
+   * For 'mfcc': each inner array has 13 coefficients.
+   */
+  features: number[][];
+  /** Identifies the feature extraction method. */
+  featureType: 'mfcc' | 'landmarks';
+  /** Sample rate of the underlying audio signal in Hz. */
+  sampleRateHz: number;
+  /** Wall-clock duration covered by this chunk in milliseconds. */
+  chunkDurationMs: number;
+}
+
+/**
  * The primary output of the system — a time-aligned piece of transcript text with metadata.
  * Produced by the server, streamed to the client, stored locally, and rendered by the UI.
  */

--- a/src/pipeline/audio/AudioChunker.ts
+++ b/src/pipeline/audio/AudioChunker.ts
@@ -1,0 +1,66 @@
+import type { AudioFeatureChunk } from '../../common/models';
+import type { MFCCFrame } from './AudioPipeline';
+
+/** Number of MFCC frames to accumulate before emitting a chunk (20 × 25 ms = 500 ms). */
+const FRAMES_PER_CHUNK = 20;
+/** Assumed sample rate of the underlying audio capture (expo-av default for HIGH_QUALITY). */
+const SAMPLE_RATE_HZ = 16000;
+/** Duration in ms of each captured frame — must match ExpoAudioPipeline.FRAME_INTERVAL_MS. */
+const FRAME_INTERVAL_MS = 25;
+
+/**
+ * Accumulates MFCCFrames from the audio pipeline and emits AudioFeatureChunks
+ * at regular intervals for transmission to the inference server.
+ *
+ * Usage:
+ *   chunker.start(sessionId)
+ *   pipeline.onFrame((f) => chunker.push(f))
+ *   chunker.onChunk((c) => transmissionManager.send(c))
+ *   chunker.stop()
+ */
+export class AudioChunker {
+  private buffer: MFCCFrame[] = [];
+  private sessionId = '';
+  private listeners = new Set<(chunk: AudioFeatureChunk) => void>();
+
+  start(sessionId: string): void {
+    this.sessionId = sessionId;
+    this.buffer = [];
+  }
+
+  push(frame: MFCCFrame): void {
+    this.buffer.push(frame);
+    if (this.buffer.length >= FRAMES_PER_CHUNK) {
+      this._flush();
+    }
+  }
+
+  stop(): void {
+    this.buffer = [];
+    this.sessionId = '';
+  }
+
+  /**
+   * Register a callback to receive completed chunks.
+   * Returns an unsubscribe function.
+   */
+  onChunk(callback: (chunk: AudioFeatureChunk) => void): () => void {
+    this.listeners.add(callback);
+    return () => this.listeners.delete(callback);
+  }
+
+  // ---------------------------------------------------------------------------
+
+  private _flush(): void {
+    const frames = this.buffer.splice(0, FRAMES_PER_CHUNK);
+    const chunk: AudioFeatureChunk = {
+      sessionId: this.sessionId,
+      timestampMs: frames[0].timestampMs,
+      features: frames.map((f) => f.coefficients),
+      featureType: 'mfcc',
+      sampleRateHz: SAMPLE_RATE_HZ,
+      chunkDurationMs: frames.length * FRAME_INTERVAL_MS,
+    };
+    this.listeners.forEach((cb) => cb(chunk));
+  }
+}

--- a/src/pipeline/audio/index.ts
+++ b/src/pipeline/audio/index.ts
@@ -1,2 +1,3 @@
 export type { IAudioPipeline, MFCCFrame } from './AudioPipeline';
 export { ExpoAudioPipeline } from './ExpoAudioPipeline';
+export { AudioChunker } from './AudioChunker';

--- a/src/ui/controller/SessionController.tsx
+++ b/src/ui/controller/SessionController.tsx
@@ -1,6 +1,7 @@
-import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { ModalityPath, SessionState } from '../../common/models';
+import { AudioChunker, ExpoAudioPipeline } from '../../pipeline/audio';
 import { TranscriptStore } from '../../store';
 
 export type SessionControllerValue = {
@@ -62,8 +63,15 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
   // Cleared at the start of each new session and on stop.
   const store = useMemo(() => new TranscriptStore(), []);
 
+  // Audio pipeline and chunker — stable across renders, one instance per provider.
+  const audioPipeline = useRef(new ExpoAudioPipeline());
+  const audioChunker = useRef(new AudioChunker());
+
   const stateRef = useRef(state);
   stateRef.current = state;
+
+  const activePathRef = useRef(activePath);
+  activePathRef.current = activePath;
 
   const getState = useCallback(() => stateRef.current, []);
 
@@ -75,6 +83,12 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
       setSessionId(newSessionId);
       setActivePath(path);
 
+      if (path === ModalityPath.SPEECH) {
+        await audioPipeline.current.start(newSessionId);
+        audioChunker.current.start(newSessionId);
+        audioPipeline.current.onFrame((frame) => audioChunker.current.push(frame));
+      }
+
       setState(SessionState.RUNNING);
     } catch (e) {
       setState(SessionState.ERROR);
@@ -83,19 +97,45 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
   }, [store]);
 
   const pauseSession = useCallback(() => {
-    setState((prev) => (prev === SessionState.RUNNING ? SessionState.PAUSED : prev));
+    if (stateRef.current !== SessionState.RUNNING) return;
+    if (activePathRef.current === ModalityPath.SPEECH) {
+      audioPipeline.current.pause();
+    }
+    setState(SessionState.PAUSED);
   }, []);
 
   const resumeSession = useCallback(() => {
-    setState((prev) => (prev === SessionState.PAUSED ? SessionState.RUNNING : prev));
+    if (stateRef.current !== SessionState.PAUSED) return;
+    if (activePathRef.current === ModalityPath.SPEECH) {
+      audioPipeline.current.resume();
+    }
+    setState(SessionState.RUNNING);
   }, []);
 
   const stopSession = useCallback(() => {
+    audioPipeline.current.stop();
+    audioChunker.current.stop();
     setState(SessionState.IDLE);
     setSessionId(null);
     setActivePath(null);
     store.clear();
   }, [store]);
+
+  // Poll audio pipeline health every second while a SPEECH session is active.
+  // Transitions RUNNING → DEGRADED if the pipeline becomes unavailable.
+  useEffect(() => {
+    if (activePath !== ModalityPath.SPEECH) return;
+    if (state !== SessionState.RUNNING && state !== SessionState.DEGRADED) return;
+
+    const interval = setInterval(() => {
+      const health = audioPipeline.current.getHealth();
+      if (!health.available && stateRef.current === SessionState.RUNNING) {
+        setState(SessionState.DEGRADED);
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [state, activePath]);
 
   const value = useMemo<SessionControllerValue>(
     () => ({


### PR DESCRIPTION
Closes #17

Wires the audio pipeline into the session lifecycle. When a SPEECH session starts, `ExpoAudioPipeline` starts capturing and `AudioChunker` starts batching the incoming MFCC frames into 500ms chunks. Pause/resume/stop all flow through to the pipeline correctly. SIGN sessions don't touch the audio pipeline at all (modal-exclusive).

Added a health poll (1s interval) that transitions the session to DEGRADED if the pipeline reports unavailable while running.

`AudioFeatureChunk` is now in `src/common/models` so the transmission layer can import it when it's ready.