### PR TITLE
feat(config): implement configuration and diagnostics package

### DIFF
--- a/__tests__/config/Configuration.test.ts
+++ b/__tests__/config/Configuration.test.ts
@@ -1,0 +1,84 @@
+import { Configuration, getDefaultAppConfig } from '@/config/Configuration';
+import { ModalityPath } from '@/common/models';
+
+type KV = {
+  getItem: (k: string) => string | null;
+  setItem: (k: string, v: string) => void;
+  removeItem: (k: string) => void;
+};
+
+function makeStorage(seed: Record<string, string> = {}): KV & { data: Record<string, string> } {
+  const data = { ...seed };
+  return {
+    data,
+    getItem: (k) => (k in data ? data[k] : null),
+    setItem: (k, v) => {
+      data[k] = v;
+    },
+    removeItem: (k) => {
+      delete data[k];
+    },
+  };
+}
+
+const KEY = 'sozia.config.v1';
+
+describe('Configuration', () => {
+  test('loads defaults when empty', async () => {
+    const s = makeStorage();
+    const cfg = new Configuration(s);
+    await cfg.load();
+
+    const d = getDefaultAppConfig();
+    expect(cfg.get('defaultPath')).toBe(d.defaultPath);
+    expect(cfg.get('fontSize')).toBe(d.fontSize);
+    expect(cfg.get('diagnosticsEnabled')).toBe(false);
+  });
+
+  test('set() updates and persists', () => {
+    const s = makeStorage();
+    const cfg = new Configuration(s);
+
+    cfg.set('fontSize', 22);
+    expect(cfg.get('fontSize')).toBe(22);
+
+    const persisted = JSON.parse(s.data[KEY]);
+    expect(persisted.fontSize).toBe(22);
+  });
+
+  test('load() reads persisted config', async () => {
+    const s = makeStorage({
+      [KEY]: JSON.stringify({
+        defaultPath: ModalityPath.SIGN,
+        fontSize: 20,
+        confidenceThreshold: 0.4,
+      }),
+    });
+    const cfg = new Configuration(s);
+    await cfg.load();
+
+    expect(cfg.get('defaultPath')).toBe(ModalityPath.SIGN);
+    expect(cfg.get('fontSize')).toBe(20);
+    expect(cfg.get('confidenceThreshold')).toBe(0.4);
+  });
+
+  test('reset() restores defaults and persists', () => {
+    const s = makeStorage();
+    const cfg = new Configuration(s);
+
+    cfg.set('fontSize', 30);
+    cfg.reset();
+
+    const d = getDefaultAppConfig();
+    expect(cfg.get('fontSize')).toBe(d.fontSize);
+    expect(JSON.parse(s.data[KEY]).fontSize).toBe(d.fontSize);
+  });
+
+  test('invalid/corrupt JSON falls back to defaults', async () => {
+    const s = makeStorage({ [KEY]: '{bad-json' });
+    const cfg = new Configuration(s);
+    await cfg.load();
+
+    expect(cfg.get('defaultPath')).toBe(ModalityPath.SPEECH);
+  });
+});

--- a/__tests__/config/DiagnosticsLogger.test.ts
+++ b/__tests__/config/DiagnosticsLogger.test.ts
@@ -1,0 +1,110 @@
+import { DiagnosticsLogger } from '@/config/DiagnosticsLogger';
+import type { AppConfig, IConfigurationManager } from '@/config/Configuration';
+
+type KV = {
+  getItem: (k: string) => string | null;
+  setItem: (k: string, v: string) => void;
+  removeItem: (k: string) => void;
+};
+
+function makeStorage(seed: Record<string, string> = {}): KV & { data: Record<string, string> } {
+  const data = { ...seed };
+  return {
+    data,
+    getItem: (k) => (k in data ? data[k] : null),
+    setItem: (k, v) => {
+      data[k] = v;
+    },
+    removeItem: (k) => {
+      delete data[k];
+    },
+  };
+}
+
+const LOG_KEY = 'sozia.diagnostics.log.v1';
+
+function makeConfig(enabled: boolean): IConfigurationManager {
+  const values: AppConfig = {
+    selectedMicId: null,
+    selectedCameraId: null,
+    defaultPath: 'SPEECH' as AppConfig['defaultPath'],
+    fontSize: 16,
+    confidenceThreshold: 0.3,
+    chunkDurationMs: 1000,
+    serverUrl: 'wss://...',
+    maxReconnectAttempts: 5,
+    diagnosticsEnabled: enabled,
+  };
+
+  return {
+    load: async () => {},
+    save: async () => {},
+    get: <K extends keyof AppConfig>(key: K): AppConfig[K] => values[key],
+    set: () => {},
+    reset: () => {},
+  };
+}
+
+describe('DiagnosticsLogger', () => {
+  test('does nothing when diagnostics disabled', async () => {
+    const s = makeStorage();
+    const logger = new DiagnosticsLogger(makeConfig(false), s);
+
+    logger.log('info', 'hello', { x: 1 });
+    await logger.flush();
+
+    expect(s.data[LOG_KEY]).toBeUndefined();
+  });
+
+  test('writes when diagnostics enabled', async () => {
+    const s = makeStorage();
+    const logger = new DiagnosticsLogger(makeConfig(true), s);
+
+    logger.log('info', 'hello', { x: 1 });
+    await logger.flush();
+
+    const entries = JSON.parse(s.data[LOG_KEY]);
+    expect(entries.length).toBe(1);
+    expect(entries[0].message).toBe('hello');
+  });
+
+  test('redacts sensitive keys', async () => {
+    const s = makeStorage();
+    const logger = new DiagnosticsLogger(makeConfig(true), s);
+
+    logger.log('warn', 'sensitive', { rawAudio: 'abc', videoFrame: [1, 2, 3] });
+    await logger.flush();
+
+    const entries = JSON.parse(s.data[LOG_KEY]);
+    expect(entries[0].data.rawAudio).toBe('[REDACTED]');
+    expect(entries[0].data.videoFrame).toBe('[REDACTED]');
+  });
+
+  test('clear removes persisted logs', async () => {
+    const s = makeStorage();
+    const logger = new DiagnosticsLogger(makeConfig(true), s);
+
+    logger.log('info', 'a');
+    await logger.flush();
+    expect(s.data[LOG_KEY]).toBeDefined();
+
+    logger.clear();
+    expect(s.data[LOG_KEY]).toBeUndefined();
+  });
+
+  test('keeps max 500 entries', async () => {
+    const s = makeStorage();
+    const logger = new DiagnosticsLogger(makeConfig(true), s);
+
+    for (let i = 0; i < 550; i++) logger.log('info', `msg-${i}`);
+    await logger.flush();
+
+    const entries = JSON.parse(s.data[LOG_KEY]);
+    expect(entries.length).toBe(500);
+  });
+
+  test('getLogPath returns stable path', () => {
+    const logger = new DiagnosticsLogger(makeConfig(true), makeStorage());
+    expect(logger.getLogPath()).toBe('local://sozia/diagnostics.log');
+  });
+});

--- a/src/config/Configuration.ts
+++ b/src/config/Configuration.ts
@@ -1,0 +1,131 @@
+import { ModalityPath } from '../common/models';
+
+const CONFIG_STORAGE_KEY = 'sozia.config.v1';
+
+export interface AppConfig {
+  selectedMicId: string | null;
+  selectedCameraId: string | null;
+  defaultPath: ModalityPath;
+  fontSize: number;
+  confidenceThreshold: number;
+  chunkDurationMs: number;
+  serverUrl: string;
+  maxReconnectAttempts: number;
+  diagnosticsEnabled: boolean;
+}
+
+export interface IConfigurationManager {
+  load(): Promise<void>;
+  save(): Promise<void>;
+  get<K extends keyof AppConfig>(key: K): AppConfig[K];
+  set<K extends keyof AppConfig>(key: K, value: AppConfig[K]): void;
+  reset(): void;
+}
+
+type KeyValueStorage = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+};
+
+const DEFAULT_CONFIG: AppConfig = {
+  selectedMicId: null,
+  selectedCameraId: null,
+  defaultPath: ModalityPath.SPEECH,
+  fontSize: 16,
+  confidenceThreshold: 0.3,
+  chunkDurationMs: 1000,
+  serverUrl: 'wss://...',
+  maxReconnectAttempts: 5,
+  diagnosticsEnabled: false,
+};
+
+function getBrowserStorage(): KeyValueStorage | null {
+  const maybeStorage = (globalThis as { localStorage?: KeyValueStorage }).localStorage;
+  if (!maybeStorage) return null;
+  if (
+    typeof maybeStorage.getItem !== 'function' ||
+    typeof maybeStorage.setItem !== 'function' ||
+    typeof maybeStorage.removeItem !== 'function'
+  ) {
+    return null;
+  }
+  return maybeStorage;
+}
+
+function clampNumber(value: unknown, fallback: number, min?: number, max?: number): number {
+  if (typeof value !== 'number' || Number.isNaN(value) || !Number.isFinite(value)) return fallback;
+  let out = value;
+  if (typeof min === 'number') out = Math.max(min, out);
+  if (typeof max === 'number') out = Math.min(max, out);
+  return out;
+}
+
+function mergeWithDefaults(raw: unknown): AppConfig {
+  if (!raw || typeof raw !== 'object') return { ...DEFAULT_CONFIG };
+  const input = raw as Partial<AppConfig>;
+  return {
+    selectedMicId: typeof input.selectedMicId === 'string' ? input.selectedMicId : null,
+    selectedCameraId: typeof input.selectedCameraId === 'string' ? input.selectedCameraId : null,
+    defaultPath: input.defaultPath === ModalityPath.SIGN ? ModalityPath.SIGN : ModalityPath.SPEECH,
+    fontSize: clampNumber(input.fontSize, DEFAULT_CONFIG.fontSize, 8, 72),
+    confidenceThreshold: clampNumber(input.confidenceThreshold, DEFAULT_CONFIG.confidenceThreshold, 0, 1),
+    chunkDurationMs: clampNumber(input.chunkDurationMs, DEFAULT_CONFIG.chunkDurationMs, 100, 10000),
+    serverUrl: typeof input.serverUrl === 'string' && input.serverUrl.length > 0
+      ? input.serverUrl
+      : DEFAULT_CONFIG.serverUrl,
+    maxReconnectAttempts: clampNumber(input.maxReconnectAttempts, DEFAULT_CONFIG.maxReconnectAttempts, 0, 50),
+    diagnosticsEnabled: input.diagnosticsEnabled === true,
+  };
+}
+
+/**
+ * Persists and provides app preferences for sozia.client.config.
+ * Backed by localStorage when available; otherwise in-memory fallback.
+ */
+export class Configuration implements IConfigurationManager {
+  private readonly storage: KeyValueStorage | null;
+  private config: AppConfig = { ...DEFAULT_CONFIG };
+
+  constructor(storage: KeyValueStorage | null = getBrowserStorage()) {
+    this.storage = storage;
+  }
+
+  async load(): Promise<void> {
+    if (!this.storage) return;
+    try {
+      const serialized = this.storage.getItem(CONFIG_STORAGE_KEY);
+      if (!serialized) {
+        this.config = { ...DEFAULT_CONFIG };
+        return;
+      }
+      this.config = mergeWithDefaults(JSON.parse(serialized));
+    } catch {
+      // Corrupted entries should never crash startup.
+      this.config = { ...DEFAULT_CONFIG };
+    }
+  }
+
+  async save(): Promise<void> {
+    if (!this.storage) return;
+    this.storage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(this.config));
+  }
+
+  get<K extends keyof AppConfig>(key: K): AppConfig[K] {
+    return this.config[key];
+  }
+
+  set<K extends keyof AppConfig>(key: K, value: AppConfig[K]): void {
+    this.config = { ...this.config, [key]: value };
+    void this.save();
+  }
+
+  reset(): void {
+    this.config = { ...DEFAULT_CONFIG };
+    void this.save();
+  }
+}
+
+export function getDefaultAppConfig(): AppConfig {
+  return { ...DEFAULT_CONFIG };
+}

--- a/src/config/DiagnosticsLogger.ts
+++ b/src/config/DiagnosticsLogger.ts
@@ -1,0 +1,109 @@
+import type { IConfigurationManager } from './Configuration';
+
+const LOG_STORAGE_KEY = 'sozia.diagnostics.log.v1';
+const MAX_ENTRIES = 500;
+
+export type DiagnosticLevel = 'info' | 'warn' | 'error';
+
+type DiagnosticEntry = {
+  ts: number;
+  level: DiagnosticLevel;
+  message: string;
+  data?: Record<string, unknown>;
+};
+
+type KeyValueStorage = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+};
+
+function getBrowserStorage(): KeyValueStorage | null {
+  const maybeStorage = (globalThis as { localStorage?: KeyValueStorage }).localStorage;
+  if (!maybeStorage) return null;
+  if (
+    typeof maybeStorage.getItem !== 'function' ||
+    typeof maybeStorage.setItem !== 'function' ||
+    typeof maybeStorage.removeItem !== 'function'
+  ) {
+    return null;
+  }
+  return maybeStorage;
+}
+
+function sanitizeData(input: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    const k = key.toLowerCase();
+    if (
+      k.includes('raw') ||
+      k.includes('audio') ||
+      k.includes('video') ||
+      k.includes('pcm') ||
+      k.includes('frame')
+    ) {
+      out[key] = '[REDACTED]';
+      continue;
+    }
+    if (Array.isArray(value)) {
+      out[key] = `[Array(${value.length})]`;
+      continue;
+    }
+    if (value && typeof value === 'object') {
+      out[key] = '[Object]';
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Opt-in diagnostics logger for sozia.client.config.
+ * Writes bounded entries to local persistent storage if available.
+ */
+export class DiagnosticsLogger {
+  private readonly config: IConfigurationManager;
+  private readonly storage: KeyValueStorage | null;
+  private entries: DiagnosticEntry[] = [];
+  private readonly logPath = 'local://sozia/diagnostics.log';
+
+  constructor(config: IConfigurationManager, storage: KeyValueStorage | null = getBrowserStorage()) {
+    this.config = config;
+    this.storage = storage;
+  }
+
+  log(level: DiagnosticLevel, message: string, data?: Record<string, unknown>): void {
+    if (!this.isEnabled()) return;
+
+    const entry: DiagnosticEntry = {
+      ts: Date.now(),
+      level,
+      message,
+      ...(data ? { data: sanitizeData(data) } : {}),
+    };
+
+    this.entries.push(entry);
+    if (this.entries.length > MAX_ENTRIES) {
+      this.entries = this.entries.slice(this.entries.length - MAX_ENTRIES);
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (!this.isEnabled() || !this.storage) return;
+    this.storage.setItem(LOG_STORAGE_KEY, JSON.stringify(this.entries));
+  }
+
+  clear(): void {
+    this.entries = [];
+    this.storage?.removeItem(LOG_STORAGE_KEY);
+  }
+
+  getLogPath(): string {
+    return this.logPath;
+  }
+
+  private isEnabled(): boolean {
+    return this.config.get('diagnosticsEnabled') === true;
+  }
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,7 @@
+export {
+  Configuration,
+  getDefaultAppConfig,
+  type AppConfig,
+  type IConfigurationManager,
+} from './Configuration';
+export { DiagnosticsLogger, type DiagnosticLevel } from './DiagnosticsLogger';


### PR DESCRIPTION
## What does this PR do?

Implements the sozia.client.config package to provide centralized configuration management and opt-in diagnostics logging, aligned with the LLD Configuration & Diagnostics section.

This PR introduces:


- Configuration service with typed config schema and defaults
- persistence lifecycle methods (load, save, get, set, reset)
- DiagnosticsLogger with opt-in behavior via diagnosticsEnabled
- basic sensitive-data redaction in diagnostic payloads
- package-level exports via src/config/index.ts
- unit tests covering config and logger behavior

Notes/discussed caveats to be explicit in review:

- src/common/interfaces/index.ts is not available on this branch baseline, so AppConfig/IConfigurationManager are currently defined in src/config/Configuration.ts and can be reconciled later after common-interfaces merge.
- Current persistence/log backend is storage-based (localStorage when available, in-memory fallback), not full native RN AsyncStorage/file-backed logging yet.
- UI/session binding is intentionally out of scope for this package-focused PR.- 

## Which package(s) does it touch?

- sozia.client.config
- tests under __tests__/config

## How to test

- npm test -- --selectProjects unit __tests__/config

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally