### PR TITLE
refactor(audio-pipeline,store,ui): align client packages with LLD spec

### DIFF
--- a/__tests__/pipeline/audio/AudioChunker.test.ts
+++ b/__tests__/pipeline/audio/AudioChunker.test.ts
@@ -1,0 +1,216 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests — AudioChunker
+ *
+ * Verifies that MFCCFrames are batched into AudioFeatureChunks correctly,
+ * listeners are notified, and start/stop resets internal state.
+ *
+ * Test plan reference: TP-CLIENT-AUDIO-005 through TP-CLIENT-AUDIO-008
+ */
+
+import { AudioChunker } from '../../../src/pipeline/audio/AudioChunker';
+import type { MFCCFrame } from '../../../src/pipeline/audio/AudioPipeline';
+import type { AudioFeatureChunk } from '../../../src/common/models';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a fake MFCCFrame with a given timestamp and deterministic coefficients. */
+function fakeFrame(timestampMs: number, seed = 0): MFCCFrame {
+  return {
+    timestampMs,
+    coefficients: Array.from({ length: 13 }, (_, i) => seed + i * 0.1),
+    energy: 0.5 + seed * 0.01,
+  };
+}
+
+/** Push `count` fake frames into the chunker, spaced 25 ms apart starting at `startMs`. */
+function pushFrames(chunker: AudioChunker, count: number, startMs = 0): void {
+  for (let i = 0; i < count; i++) {
+    chunker.push(fakeFrame(startMs + i * 25, i));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AudioChunker', () => {
+  let chunker: AudioChunker;
+
+  beforeEach(() => {
+    chunker = new AudioChunker();
+    chunker.start('session-1');
+  });
+
+  afterEach(() => {
+    chunker.stop();
+  });
+
+  // -- TP-CLIENT-AUDIO-005: chunk emission after FRAMES_PER_CHUNK frames ---
+
+  it('emits a chunk after 20 frames', () => {
+    const chunks: AudioFeatureChunk[] = [];
+    chunker.onChunk((c) => chunks.push(c));
+
+    pushFrames(chunker, 20);
+
+    expect(chunks).toHaveLength(1);
+  });
+
+  it('does not emit a chunk before 20 frames', () => {
+    const chunks: AudioFeatureChunk[] = [];
+    chunker.onChunk((c) => chunks.push(c));
+
+    pushFrames(chunker, 19);
+
+    expect(chunks).toHaveLength(0);
+  });
+
+  it('emits two chunks after 40 frames', () => {
+    const chunks: AudioFeatureChunk[] = [];
+    chunker.onChunk((c) => chunks.push(c));
+
+    pushFrames(chunker, 40);
+
+    expect(chunks).toHaveLength(2);
+  });
+
+  it('buffers leftover frames for the next chunk', () => {
+    const chunks: AudioFeatureChunk[] = [];
+    chunker.onChunk((c) => chunks.push(c));
+
+    pushFrames(chunker, 25);
+    expect(chunks).toHaveLength(1);
+
+    // 5 leftover + 15 more = 20 → second chunk
+    pushFrames(chunker, 15, 25 * 25);
+    expect(chunks).toHaveLength(2);
+  });
+
+  // -- TP-CLIENT-AUDIO-006: chunk content correctness -----------------------
+
+  it('sets sessionId from start()', () => {
+    const chunks: AudioFeatureChunk[] = [];
+    chunker.onChunk((c) => chunks.push(c));
+
+    pushFrames(chunker, 20);
+
+    expect(chunks[0].sessionId).toBe('session-1');
+  });
+
+  it('uses the first frame timestamp as chunk timestampMs', () => {
+    const chunks: AudioFeatureChunk[] = [];
+    chunker.onChunk((c) => chunks.push(c));
+
+    pushFrames(chunker, 20, 1000);
+
+    expect(chunks[0].timestampMs).toBe(1000);
+  });
+
+  it('maps frame coefficients into features array', () => {
+    const chunks: AudioFeatureChunk[] = [];
+    chunker.onChunk((c) => chunks.push(c));
+
+    pushFrames(chunker, 20);
+
+    expect(chunks[0].features).toHaveLength(20);
+    expect(chunks[0].features[0]).toHaveLength(13);
+  });
+
+  it('sets featureType to mfcc', () => {
+    const chunks: AudioFeatureChunk[] = [];
+    chunker.onChunk((c) => chunks.push(c));
+
+    pushFrames(chunker, 20);
+
+    expect(chunks[0].featureType).toBe('mfcc');
+  });
+
+  it('sets sampleRateHz to 16000', () => {
+    const chunks: AudioFeatureChunk[] = [];
+    chunker.onChunk((c) => chunks.push(c));
+
+    pushFrames(chunker, 20);
+
+    expect(chunks[0].sampleRateHz).toBe(16000);
+  });
+
+  it('calculates chunkDurationMs as frames × 25ms', () => {
+    const chunks: AudioFeatureChunk[] = [];
+    chunker.onChunk((c) => chunks.push(c));
+
+    pushFrames(chunker, 20);
+
+    expect(chunks[0].chunkDurationMs).toBe(500);
+  });
+
+  // -- TP-CLIENT-AUDIO-007: listener management -----------------------------
+
+  it('notifies multiple listeners', () => {
+    let countA = 0;
+    let countB = 0;
+    chunker.onChunk(() => countA++);
+    chunker.onChunk(() => countB++);
+
+    pushFrames(chunker, 20);
+
+    expect(countA).toBe(1);
+    expect(countB).toBe(1);
+  });
+
+  it('stops notifying after unsubscribe', () => {
+    let count = 0;
+    const unsub = chunker.onChunk(() => count++);
+
+    pushFrames(chunker, 20);
+    expect(count).toBe(1);
+
+    unsub();
+    pushFrames(chunker, 20, 20 * 25);
+    expect(count).toBe(1);
+  });
+
+  // -- TP-CLIENT-AUDIO-008: start/stop lifecycle ----------------------------
+
+  it('clears buffer on stop', () => {
+    const chunks: AudioFeatureChunk[] = [];
+    chunker.onChunk((c) => chunks.push(c));
+
+    pushFrames(chunker, 10);
+    chunker.stop();
+    chunker.start('session-2');
+    pushFrames(chunker, 20);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].sessionId).toBe('session-2');
+  });
+
+  it('uses new sessionId after restart', () => {
+    const chunks: AudioFeatureChunk[] = [];
+    chunker.onChunk((c) => chunks.push(c));
+
+    pushFrames(chunker, 20);
+    chunker.stop();
+    chunker.start('session-2');
+    pushFrames(chunker, 20, 20 * 25);
+
+    expect(chunks[0].sessionId).toBe('session-1');
+    expect(chunks[1].sessionId).toBe('session-2');
+  });
+
+  it('clears buffer on start (fresh session)', () => {
+    const chunks: AudioFeatureChunk[] = [];
+    chunker.onChunk((c) => chunks.push(c));
+
+    pushFrames(chunker, 15);
+    chunker.start('session-2'); // restart without stop — should clear buffer
+    pushFrames(chunker, 20);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].sessionId).toBe('session-2');
+  });
+});

--- a/__tests__/store/TranscriptStore.test.ts
+++ b/__tests__/store/TranscriptStore.test.ts
@@ -14,6 +14,15 @@ import { TranscriptExporter } from '../../src/store/TranscriptExporter';
 import type { TranscriptSegment } from '../../src/common/models';
 import { SegmentStatus, ModalityType } from '../../src/common/models';
 
+// Mock expo-file-system/next for TranscriptExporter tests
+const mockWrite = jest.fn();
+jest.mock('expo-file-system/next', () => ({
+  File: jest.fn().mockImplementation((path: string) => ({
+    uri: path,
+    write: mockWrite,
+  })),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -38,10 +47,10 @@ function makeSegment(overrides: Partial<TranscriptSegment> = {}): TranscriptSegm
 }
 
 // ---------------------------------------------------------------------------
-// TP-CLIENT-STORE-001: Basic append and retrieval
+// TP-CLIENT-STORE-001: Basic receiveSegment and retrieval
 // ---------------------------------------------------------------------------
 
-describe('TranscriptStore — append and retrieval', () => {
+describe('TranscriptStore — receiveSegment and retrieval', () => {
   let store: TranscriptStore;
 
   beforeEach(() => {
@@ -50,29 +59,29 @@ describe('TranscriptStore — append and retrieval', () => {
   });
 
   it('TP-CLIENT-STORE-001a: starts empty', () => {
-    expect(store.getAll()).toEqual([]);
+    expect(store.getSegments()).toEqual([]);
     expect(store.size).toBe(0);
   });
 
-  it('TP-CLIENT-STORE-001b: append adds a segment', () => {
-    store.append(makeSegment());
+  it('TP-CLIENT-STORE-001b: receiveSegment adds a segment', () => {
+    store.receiveSegment(makeSegment());
     expect(store.size).toBe(1);
   });
 
-  it('TP-CLIENT-STORE-001c: getAll returns a copy, not the internal array', () => {
-    store.append(makeSegment());
-    const first = store.getAll();
-    const second = store.getAll();
+  it('TP-CLIENT-STORE-001c: getSegments returns a copy, not the internal array', () => {
+    store.receiveSegment(makeSegment());
+    const first = store.getSegments();
+    const second = store.getSegments();
     expect(first).not.toBe(second); // different references
     expect(first).toEqual(second);  // same contents
   });
 
-  it('TP-CLIENT-STORE-001d: segments are sorted by timestampMs after append', () => {
-    store.append(makeSegment({ timestampMs: 3000 }));
-    store.append(makeSegment({ timestampMs: 1000 }));
-    store.append(makeSegment({ timestampMs: 2000 }));
+  it('TP-CLIENT-STORE-001d: segments are sorted by timestampMs after receiveSegment', () => {
+    store.receiveSegment(makeSegment({ timestampMs: 3000 }));
+    store.receiveSegment(makeSegment({ timestampMs: 1000 }));
+    store.receiveSegment(makeSegment({ timestampMs: 2000 }));
 
-    const timestamps = store.getAll().map((s) => s.timestampMs);
+    const timestamps = store.getSegments().map((s) => s.timestampMs);
     expect(timestamps).toEqual([1000, 2000, 3000]);
   });
 });
@@ -104,12 +113,12 @@ describe('TranscriptStore — partial → final replacement', () => {
       replacesSegmentId: 'partial-1',
     });
 
-    store.append(partial);
-    store.append(final);
+    store.receiveSegment(partial);
+    store.receiveSegment(final);
 
     expect(store.size).toBe(1);
-    expect(store.getAll()[0].text).toBe('Merhaba dünya');
-    expect(store.getAll()[0].status).toBe(SegmentStatus.FINAL);
+    expect(store.getSegments()[0].text).toBe('Merhaba dünya');
+    expect(store.getSegments()[0].status).toBe(SegmentStatus.FINAL);
   });
 
   it('TP-CLIENT-STORE-002b: replacement preserves display order', () => {
@@ -122,13 +131,13 @@ describe('TranscriptStore — partial → final replacement', () => {
       replacesSegmentId: 'p1',
     });
 
-    store.append(p1);
-    store.append(p2);
-    store.append(f1);
+    store.receiveSegment(p1);
+    store.receiveSegment(p2);
+    store.receiveSegment(f1);
 
     expect(store.size).toBe(2);
-    expect(store.getAll()[0].segmentId).toBe('f1');
-    expect(store.getAll()[1].segmentId).toBe('p2');
+    expect(store.getSegments()[0].segmentId).toBe('f1');
+    expect(store.getSegments()[1].segmentId).toBe('p2');
   });
 
   it('TP-CLIENT-STORE-002c: FINAL is appended if referenced PARTIAL is not found', () => {
@@ -138,18 +147,55 @@ describe('TranscriptStore — partial → final replacement', () => {
       replacesSegmentId: 'nonexistent',
     });
 
-    store.append(final);
+    store.receiveSegment(final);
 
     expect(store.size).toBe(1);
-    expect(store.getAll()[0].segmentId).toBe('f1');
+    expect(store.getSegments()[0].segmentId).toBe('f1');
   });
 });
 
 // ---------------------------------------------------------------------------
-// TP-CLIENT-STORE-003: Clear and observer
+// TP-CLIENT-STORE-002d: getSegmentById
 // ---------------------------------------------------------------------------
 
-describe('TranscriptStore — clear and onUpdate', () => {
+describe('TranscriptStore — getSegmentById', () => {
+  let store: TranscriptStore;
+
+  beforeEach(() => {
+    store = new TranscriptStore();
+    _segCounter = 0;
+  });
+
+  it('returns null when segment does not exist', () => {
+    expect(store.getSegmentById('nonexistent')).toBeNull();
+  });
+
+  it('returns the segment when it exists', () => {
+    const seg = makeSegment({ segmentId: 'abc' });
+    store.receiveSegment(seg);
+    expect(store.getSegmentById('abc')).toEqual(seg);
+  });
+
+  it('returns null after clear', () => {
+    store.receiveSegment(makeSegment({ segmentId: 'abc' }));
+    store.clear();
+    expect(store.getSegmentById('abc')).toBeNull();
+  });
+
+  it('returns the replacement after partial → final', () => {
+    store.receiveSegment(makeSegment({ segmentId: 'p1', status: SegmentStatus.PARTIAL }));
+    const final = makeSegment({ segmentId: 'f1', replacesSegmentId: 'p1' });
+    store.receiveSegment(final);
+    expect(store.getSegmentById('f1')).toEqual(final);
+    expect(store.getSegmentById('p1')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-STORE-003: Clear and subscribe
+// ---------------------------------------------------------------------------
+
+describe('TranscriptStore — clear and subscribe', () => {
   let store: TranscriptStore;
 
   beforeEach(() => {
@@ -158,25 +204,25 @@ describe('TranscriptStore — clear and onUpdate', () => {
   });
 
   it('TP-CLIENT-STORE-003a: clear removes all segments', () => {
-    store.append(makeSegment());
-    store.append(makeSegment());
+    store.receiveSegment(makeSegment());
+    store.receiveSegment(makeSegment());
     store.clear();
     expect(store.size).toBe(0);
   });
 
-  it('TP-CLIENT-STORE-003b: onUpdate fires on append with the current snapshot', () => {
+  it('TP-CLIENT-STORE-003b: subscribe fires on receiveSegment with the current snapshot', () => {
     const received: TranscriptSegment[][] = [];
-    store.onUpdate((s) => received.push(s));
+    store.subscribe((s) => received.push(s));
 
-    store.append(makeSegment());
+    store.receiveSegment(makeSegment());
     expect(received).toHaveLength(1);
     expect(received[0]).toHaveLength(1);
   });
 
-  it('TP-CLIENT-STORE-003c: onUpdate fires on clear with an empty array', () => {
-    store.append(makeSegment());
+  it('TP-CLIENT-STORE-003c: subscribe fires on clear with an empty array', () => {
+    store.receiveSegment(makeSegment());
     const received: TranscriptSegment[][] = [];
-    store.onUpdate((s) => received.push(s));
+    store.subscribe((s) => received.push(s));
 
     store.clear();
     expect(received).toHaveLength(1);
@@ -185,11 +231,11 @@ describe('TranscriptStore — clear and onUpdate', () => {
 
   it('TP-CLIENT-STORE-003d: unsubscribe stops update delivery', () => {
     const received: TranscriptSegment[][] = [];
-    const unsub = store.onUpdate((s) => received.push(s));
+    const unsub = store.subscribe((s) => received.push(s));
 
-    store.append(makeSegment());
+    store.receiveSegment(makeSegment());
     unsub();
-    store.append(makeSegment());
+    store.receiveSegment(makeSegment());
 
     expect(received).toHaveLength(1);
   });
@@ -197,10 +243,10 @@ describe('TranscriptStore — clear and onUpdate', () => {
   it('TP-CLIENT-STORE-003e: multiple listeners receive updates simultaneously', () => {
     const countA = { n: 0 };
     const countB = { n: 0 };
-    store.onUpdate(() => countA.n++);
-    store.onUpdate(() => countB.n++);
+    store.subscribe(() => countA.n++);
+    store.subscribe(() => countB.n++);
 
-    store.append(makeSegment());
+    store.receiveSegment(makeSegment());
     expect(countA.n).toBe(1);
     expect(countB.n).toBe(1);
   });
@@ -211,64 +257,78 @@ describe('TranscriptStore — clear and onUpdate', () => {
 // ---------------------------------------------------------------------------
 
 describe('TranscriptExporter', () => {
-  let store: TranscriptStore;
   let exporter: TranscriptExporter;
 
   beforeEach(() => {
-    store = new TranscriptStore();
-    exporter = new TranscriptExporter(store);
+    exporter = new TranscriptExporter();
+    mockWrite.mockClear();
     _segCounter = 0;
   });
 
-  it('TP-CLIENT-STORE-004a: exportAsText returns empty string when store is empty', () => {
-    expect(exporter.exportAsText()).toBe('');
+  it('TP-CLIENT-STORE-004a: exportAsText writes empty string when segments is empty', async () => {
+    await exporter.exportAsText([], '/tmp/test.txt');
+    expect(mockWrite).toHaveBeenCalledWith('');
   });
 
-  it('TP-CLIENT-STORE-004b: exportAsText includes only FINAL segments', () => {
-    store.append(makeSegment({ segmentId: 'p1', status: SegmentStatus.PARTIAL, text: 'MERHABA' }));
-    store.append(makeSegment({ segmentId: 'f1', status: SegmentStatus.FINAL, text: 'Merhaba' }));
+  it('TP-CLIENT-STORE-004b: exportAsText includes only FINAL segments (plus trailing PARTIAL)', async () => {
+    const segments = [
+      makeSegment({ segmentId: 'p1', status: SegmentStatus.PARTIAL, text: 'MERHABA' }),
+      makeSegment({ segmentId: 'f1', status: SegmentStatus.FINAL, text: 'Merhaba' }),
+    ];
 
-    const text = exporter.exportAsText({ includeTimestamps: false });
-    expect(text).toBe('Merhaba');
-    expect(text).not.toContain('MERHABA');
+    await exporter.exportAsText(segments, '/tmp/test.txt');
+    const written = mockWrite.mock.calls[0][0] as string;
+    expect(written).toContain('Merhaba');
+    expect(written).not.toContain('MERHABA');
   });
 
-  it('TP-CLIENT-STORE-004c: exportAsText includes formatted timestamps by default', () => {
-    store.append(makeSegment({ status: SegmentStatus.FINAL, text: 'Test', timestampMs: 83456 }));
-    const text = exporter.exportAsText();
-    expect(text).toMatch(/^\[01:23\.456\]/);
+  it('TP-CLIENT-STORE-004c: exportAsText includes formatted HH:MM:SS timestamps', async () => {
+    const segments = [
+      makeSegment({ status: SegmentStatus.FINAL, text: 'Test', timestampMs: 83456 }),
+    ];
+    await exporter.exportAsText(segments, '/tmp/test.txt');
+    const written = mockWrite.mock.calls[0][0] as string;
+    expect(written).toMatch(/^\[00:01:23\]/);
   });
 
-  it('TP-CLIENT-STORE-004d: exportAsText omits timestamps when includeTimestamps is false', () => {
-    store.append(makeSegment({ status: SegmentStatus.FINAL, text: 'Tamam' }));
-    const text = exporter.exportAsText({ includeTimestamps: false });
-    expect(text).toBe('Tamam');
-    expect(text).not.toContain('[');
+  it('TP-CLIENT-STORE-004d: exportAsText includes trailing PARTIAL when it is the last segment', async () => {
+    const segments = [
+      makeSegment({ status: SegmentStatus.FINAL, text: 'Birinci', timestampMs: 1000 }),
+      makeSegment({ status: SegmentStatus.PARTIAL, text: 'İkinci…', timestampMs: 2000 }),
+    ];
+    await exporter.exportAsText(segments, '/tmp/test.txt');
+    const written = mockWrite.mock.calls[0][0] as string;
+    expect(written).toContain('İkinci…');
   });
 
-  it('TP-CLIENT-STORE-004e: exportAsJson returns valid JSON containing all segments', () => {
-    const seg = makeSegment({ status: SegmentStatus.FINAL, text: 'Evet' });
-    store.append(seg);
-
-    const json = exporter.exportAsJson();
-    const parsed = JSON.parse(json) as TranscriptSegment[];
+  it('TP-CLIENT-STORE-004e: exportAsJson writes valid JSON containing all segments', async () => {
+    const segments = [makeSegment({ status: SegmentStatus.FINAL, text: 'Evet' })];
+    await exporter.exportAsJson(segments, '/tmp/test.json');
+    const written = mockWrite.mock.calls[0][0] as string;
+    const parsed = JSON.parse(written) as TranscriptSegment[];
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed).toHaveLength(1);
     expect(parsed[0].text).toBe('Evet');
   });
 
-  it('TP-CLIENT-STORE-004f: exportAsJson includes PARTIAL segments', () => {
-    store.append(makeSegment({ status: SegmentStatus.PARTIAL, text: 'EVET' }));
-    const parsed = JSON.parse(exporter.exportAsJson()) as TranscriptSegment[];
+  it('TP-CLIENT-STORE-004f: exportAsJson includes PARTIAL segments', async () => {
+    const segments = [makeSegment({ status: SegmentStatus.PARTIAL, text: 'EVET' })];
+    await exporter.exportAsJson(segments, '/tmp/test.json');
+    const written = mockWrite.mock.calls[0][0] as string;
+    const parsed = JSON.parse(written) as TranscriptSegment[];
     expect(parsed).toHaveLength(1);
     expect(parsed[0].status).toBe(SegmentStatus.PARTIAL);
   });
 
-  it('TP-CLIENT-STORE-004g: exportAsText joins multiple segments with newlines', () => {
-    store.append(makeSegment({ status: SegmentStatus.FINAL, text: 'Birinci', timestampMs: 1000 }));
-    store.append(makeSegment({ status: SegmentStatus.FINAL, text: 'İkinci', timestampMs: 2000 }));
-
-    const text = exporter.exportAsText({ includeTimestamps: false });
-    expect(text).toBe('Birinci\nİkinci');
+  it('TP-CLIENT-STORE-004g: exportAsText joins multiple segments with newlines', async () => {
+    const segments = [
+      makeSegment({ status: SegmentStatus.FINAL, text: 'Birinci', timestampMs: 1000 }),
+      makeSegment({ status: SegmentStatus.FINAL, text: 'İkinci', timestampMs: 2000 }),
+    ];
+    await exporter.exportAsText(segments, '/tmp/test.txt');
+    const written = mockWrite.mock.calls[0][0] as string;
+    expect(written).toContain('Birinci');
+    expect(written).toContain('İkinci');
+    expect(written.split('\n')).toHaveLength(2);
   });
 });

--- a/__tests__/ui/testing/MockTranscriptSource.test.ts
+++ b/__tests__/ui/testing/MockTranscriptSource.test.ts
@@ -38,7 +38,7 @@ describe('MockTranscriptSource', () => {
   it('emits a PARTIAL segment after the first interval', () => {
     source.start();
     jest.advanceTimersByTime(2000);
-    const segments = store.getAll();
+    const segments = store.getSegments();
     expect(segments.length).toBeGreaterThanOrEqual(1);
     expect(segments[0].status).toBe(SegmentStatus.PARTIAL);
     expect(segments[0].sessionId).toBe('test-session');
@@ -48,11 +48,11 @@ describe('MockTranscriptSource', () => {
     source.start();
     // First tick: PARTIAL
     jest.advanceTimersByTime(2000);
-    const partialId = store.getAll()[0].segmentId;
+    const partialId = store.getSegments()[0].segmentId;
 
     // Second tick: FINAL replacing the partial
     jest.advanceTimersByTime(1500);
-    const segments = store.getAll();
+    const segments = store.getSegments();
     const finalSeg = segments.find((s) => s.status === SegmentStatus.FINAL);
     expect(finalSeg).toBeDefined();
     expect(finalSeg!.replacesSegmentId).toBe(partialId);
@@ -61,11 +61,11 @@ describe('MockTranscriptSource', () => {
   it('stops emitting after stop is called', () => {
     source.start();
     jest.advanceTimersByTime(2000);
-    const countAfterFirst = store.getAll().length;
+    const countAfterFirst = store.getSegments().length;
 
     source.stop();
     jest.advanceTimersByTime(10000);
-    expect(store.getAll().length).toBe(countAfterFirst);
+    expect(store.getSegments().length).toBe(countAfterFirst);
   });
 
   it('varies source modality across emissions', () => {
@@ -74,7 +74,7 @@ describe('MockTranscriptSource', () => {
     for (let i = 0; i < 12; i++) {
       jest.advanceTimersByTime(2000);
     }
-    const sources = store.getAll().map((s) => s.source);
+    const sources = store.getSegments().map((s) => s.source);
     const uniqueSources = new Set(sources);
     expect(uniqueSources.size).toBeGreaterThan(1);
   });
@@ -84,7 +84,7 @@ describe('MockTranscriptSource', () => {
     for (let i = 0; i < 20; i++) {
       jest.advanceTimersByTime(2000);
     }
-    const hasLowConfidence = store.getAll().some((s) => s.confidence < 0.5);
+    const hasLowConfidence = store.getSegments().some((s) => s.confidence < 0.5);
     expect(hasLowConfidence).toBe(true);
   });
 
@@ -92,6 +92,6 @@ describe('MockTranscriptSource', () => {
     source.start();
     source.start();
     jest.advanceTimersByTime(2000);
-    expect(store.getAll().length).toBe(1);
+    expect(store.getSegments().length).toBe(1);
   });
 });

--- a/src/common/models/index.ts
+++ b/src/common/models/index.ts
@@ -107,7 +107,7 @@ export interface AudioFeatureChunk {
    */
   features: number[][];
   /** Identifies the feature extraction method. */
-  featureType: 'mfcc' | 'landmarks';
+  featureType: 'mfcc' | 'mel_spectrogram';
   /** Sample rate of the underlying audio signal in Hz. */
   sampleRateHz: number;
   /** Wall-clock duration covered by this chunk in milliseconds. */

--- a/src/pipeline/audio/AudioChunker.ts
+++ b/src/pipeline/audio/AudioChunker.ts
@@ -1,10 +1,6 @@
 import type { AudioFeatureChunk } from '../../common/models';
 import type { MFCCFrame } from './AudioPipeline';
 
-/** Number of MFCC frames to accumulate before emitting a chunk (20 × 25 ms = 500 ms). */
-const FRAMES_PER_CHUNK = 20;
-/** Assumed sample rate of the underlying audio capture (expo-av default for HIGH_QUALITY). */
-const SAMPLE_RATE_HZ = 16000;
 /** Duration in ms of each captured frame — must match ExpoAudioPipeline.FRAME_INTERVAL_MS. */
 const FRAME_INTERVAL_MS = 25;
 
@@ -12,16 +8,36 @@ const FRAME_INTERVAL_MS = 25;
  * Accumulates MFCCFrames from the audio pipeline and emits AudioFeatureChunks
  * at regular intervals for transmission to the inference server.
  *
- * Usage:
+ * Collaborators: ExpoAudioPipeline (produces frames), TransmissionManager (consumes chunks).
+ *
+ * Thread/concurrency: single-threaded, safe from any async context.
+ *
+ * @example
  *   chunker.start(sessionId)
  *   pipeline.onFrame((f) => chunker.push(f))
  *   chunker.onChunk((c) => transmissionManager.send(c))
  *   chunker.stop()
  */
 export class AudioChunker {
+  /** Duration of each emitted chunk in milliseconds. Configurable via Configuration. */
+  readonly chunkDurationMs: number;
+  /** Audio sample rate in Hz. Configurable via Configuration. */
+  readonly sampleRateHz: number;
+
+  private framesPerChunk: number;
   private buffer: MFCCFrame[] = [];
   private sessionId = '';
   private listeners = new Set<(chunk: AudioFeatureChunk) => void>();
+
+  /**
+   * @param chunkDurationMs - Duration of each chunk (default: 500 ms).
+   * @param sampleRateHz - Audio sample rate (default: 16 000 Hz).
+   */
+  constructor(chunkDurationMs = 500, sampleRateHz = 16000) {
+    this.chunkDurationMs = chunkDurationMs;
+    this.sampleRateHz = sampleRateHz;
+    this.framesPerChunk = Math.round(chunkDurationMs / FRAME_INTERVAL_MS);
+  }
 
   start(sessionId: string): void {
     this.sessionId = sessionId;
@@ -30,7 +46,7 @@ export class AudioChunker {
 
   push(frame: MFCCFrame): void {
     this.buffer.push(frame);
-    if (this.buffer.length >= FRAMES_PER_CHUNK) {
+    if (this.buffer.length >= this.framesPerChunk) {
       this._flush();
     }
   }
@@ -52,13 +68,13 @@ export class AudioChunker {
   // ---------------------------------------------------------------------------
 
   private _flush(): void {
-    const frames = this.buffer.splice(0, FRAMES_PER_CHUNK);
+    const frames = this.buffer.splice(0, this.framesPerChunk);
     const chunk: AudioFeatureChunk = {
       sessionId: this.sessionId,
       timestampMs: frames[0].timestampMs,
       features: frames.map((f) => f.coefficients),
       featureType: 'mfcc',
-      sampleRateHz: SAMPLE_RATE_HZ,
+      sampleRateHz: this.sampleRateHz,
       chunkDurationMs: frames.length * FRAME_INTERVAL_MS,
     };
     this.listeners.forEach((cb) => cb(chunk));

--- a/src/pipeline/audio/AudioPipeline.ts
+++ b/src/pipeline/audio/AudioPipeline.ts
@@ -36,7 +36,9 @@ export interface IAudioPipeline {
   /**
    * Begin microphone capture and MFCC extraction for the given session.
    * Resolves once the pipeline is ready to emit frames.
-   * Rejects if microphone permission is denied or the device is unavailable.
+   * Rejects if the device is unavailable.
+   *
+   * @param sessionId - UUID v4 of the active session.
    */
   start(sessionId: string): Promise<void>;
 

--- a/src/store/TranscriptExporter.ts
+++ b/src/store/TranscriptExporter.ts
@@ -1,92 +1,78 @@
-import type { TranscriptSegment } from '../common/models';
-import type { TranscriptStore } from './TranscriptStore';
+import { File } from 'expo-file-system/next';
 
-/** Plain-text export options. */
-export interface TextExportOptions {
-  /**
-   * If true, each line is prefixed with a `[mm:ss.ms]` timestamp.
-   * Defaults to true.
-   */
-  includeTimestamps?: boolean;
-}
+import { SegmentStatus, type TranscriptSegment } from '../common/models';
 
 /**
- * Exports the contents of a {@link TranscriptStore} to portable formats.
+ * Exports a transcript timeline to a local file.
  *
- * Reads a snapshot from the store at export time — mutations after the call
- * return do not affect the export output.
+ * Stateless utility — accepts a segment snapshot and a target path per call.
+ * Does not hold a reference to TranscriptStore.
  *
- * Collaborators: reads from {@link TranscriptStore}.
+ * Collaborators: reads from {@link TranscriptStore} via caller-provided snapshot.
  *
  * Thread/concurrency: stateless and safe to call from any async context.
  */
 export class TranscriptExporter {
-  private readonly store: TranscriptStore;
-
   /**
-   * @param store - The transcript store to export from.
-   */
-  constructor(store: TranscriptStore) {
-    this.store = store;
-  }
-
-  /**
-   * Export all FINAL segments as a plain-text string, one segment per line.
-   * PARTIAL segments are excluded — only committed, fused text is exported.
+   * Export segments as a plain-text file, one segment per line.
    *
-   * @param options - Optional formatting controls.
-   * @returns UTF-8 plain text. Empty string if no FINAL segments exist.
+   * Only FINAL segments are included, except when the last segment in the
+   * timeline is still PARTIAL — it is kept to ensure the final context is
+   * not lost (per LLD Section 3.2.6).
    *
-   * @example
-   * const text = exporter.exportAsText({ includeTimestamps: true });
-   * // "[00:01.320] Merhaba, nasılsın?\n[00:03.750] İyiyim, teşekkür ederim."
+   * @param segments - Ordered transcript segments to export.
+   * @param filePath - Absolute path for the output file.
    */
-  exportAsText(options: TextExportOptions = {}): string {
-    const { includeTimestamps = true } = options;
-    const finals = this._finalSegments();
-
-    return finals
-      .map((s) => {
-        if (includeTimestamps) {
-          return `[${TranscriptExporter._formatTimestamp(s.timestampMs)}] ${s.text}`;
-        }
-        return s.text;
-      })
+  async exportAsText(segments: TranscriptSegment[], filePath: string): Promise<void> {
+    const included = this._finalsPlusTrailingPartial(segments);
+    const text = included
+      .map((s) => `[${TranscriptExporter._formatTimestamp(s.timestampMs)}] ${s.text}`)
       .join('\n');
+    const file = new File(filePath);
+    file.write(text);
   }
 
   /**
-   * Export all segments (PARTIAL and FINAL) as a JSON string.
+   * Export all segments (PARTIAL and FINAL) as a JSON file.
    * Includes all metadata fields, suitable for debugging or archival.
    *
-   * @returns JSON string containing an array of {@link TranscriptSegment} objects.
-   *
-   * @example
-   * const json = exporter.exportAsJson();
-   * // '[{"segmentId":"...","status":"FINAL","text":"Merhaba",...}]'
+   * @param segments - Ordered transcript segments to export.
+   * @param filePath - Absolute path for the output file.
    */
-  exportAsJson(): string {
-    return JSON.stringify(this.store.getAll(), null, 2);
+  async exportAsJson(segments: TranscriptSegment[], filePath: string): Promise<void> {
+    const json = JSON.stringify(segments, null, 2);
+    const file = new File(filePath);
+    file.write(json);
   }
 
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
 
-  private _finalSegments(): TranscriptSegment[] {
-    return this.store.getAll().filter((s) => s.status === 'FINAL');
+  /**
+   * Returns all FINAL segments, plus the trailing PARTIAL if the last segment
+   * in the timeline hasn't been finalized yet.
+   */
+  private _finalsPlusTrailingPartial(segments: TranscriptSegment[]): TranscriptSegment[] {
+    const finals = segments.filter((s) => s.status === SegmentStatus.FINAL);
+    if (segments.length > 0) {
+      const last = segments[segments.length - 1];
+      if (last.status === SegmentStatus.PARTIAL) {
+        finals.push(last);
+      }
+    }
+    return finals;
   }
 
   /**
-   * Formats a session-relative millisecond timestamp as `mm:ss.ms`.
+   * Formats a session-relative millisecond timestamp as `HH:MM:SS`.
    * @param ms - Milliseconds since session start.
-   * @returns Formatted string, e.g. `"01:23.456"`.
    */
   private static _formatTimestamp(ms: number): string {
     const totalSeconds = Math.floor(ms / 1000);
-    const minutes = Math.floor(totalSeconds / 60);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
     const seconds = totalSeconds % 60;
-    const millis = ms % 1000;
-    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}.${String(millis).padStart(3, '0')}`;
+    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
   }
 }

--- a/src/store/TranscriptStore.ts
+++ b/src/store/TranscriptStore.ts
@@ -10,7 +10,7 @@ import type { TranscriptSegment } from '../common/models';
  * not found, the FINAL is appended as a new entry.
  *
  * Collaborators: {@link TranscriptExporter} reads snapshots from this store.
- * The UI `TranscriptView` subscribes via {@link onUpdate} to re-render on
+ * The UI `TranscriptView` subscribes via {@link subscribe} to re-render on
  * every change.
  *
  * Thread/concurrency: JavaScript single-threaded — all mutations are
@@ -18,26 +18,22 @@ import type { TranscriptSegment } from '../common/models';
  */
 export class TranscriptStore {
   private segments: TranscriptSegment[] = [];
+  private segmentIndex = new Map<string, number>();
   private listeners = new Set<(segments: TranscriptSegment[]) => void>();
 
   /**
-   * Add a new segment to the timeline.
-   *
-   * If `segment.replacesSegmentId` is non-null, the store first attempts to
-   * replace the referenced segment in-place. If the referenced segment is not
-   * found (e.g., already cleared), the segment is appended at the end.
-   *
-   * The timeline is kept sorted by `timestampMs` after every append.
+   * Core method. If `segment.replacesSegmentId` is non-null, finds and
+   * replaces the target segment. Otherwise, appends. Notifies all listeners.
    *
    * @param segment - The transcript segment to add or use as a replacement.
    */
-  append(segment: TranscriptSegment): void {
+  receiveSegment(segment: TranscriptSegment): void {
     if (segment.replacesSegmentId !== null) {
-      const idx = this.segments.findIndex(
-        (s) => s.segmentId === segment.replacesSegmentId
-      );
-      if (idx !== -1) {
+      const idx = this.segmentIndex.get(segment.replacesSegmentId);
+      if (idx !== undefined && idx < this.segments.length && this.segments[idx].segmentId === segment.replacesSegmentId) {
+        this.segmentIndex.delete(segment.replacesSegmentId);
         this.segments[idx] = segment;
+        this.segmentIndex.set(segment.segmentId, idx);
         this._notify();
         return;
       }
@@ -45,6 +41,7 @@ export class TranscriptStore {
 
     this.segments.push(segment);
     this.segments.sort((a, b) => a.timestampMs - b.timestampMs);
+    this._rebuildIndex();
     this._notify();
   }
 
@@ -54,17 +51,29 @@ export class TranscriptStore {
    */
   clear(): void {
     this.segments = [];
+    this.segmentIndex.clear();
     this._notify();
   }
 
   /**
-   * Returns a shallow copy of the current segment list, ordered by `timestampMs`.
-   * Safe to iterate without holding a lock.
+   * Returns a read-only copy of the current segment list, ordered by `timestampMs`.
    *
    * @returns Ordered array of transcript segments.
    */
-  getAll(): TranscriptSegment[] {
+  getSegments(): TranscriptSegment[] {
     return [...this.segments];
+  }
+
+  /**
+   * Looks up a segment by ID.
+   *
+   * @param segmentId - The UUID of the segment to find.
+   * @returns The segment if found, or null.
+   */
+  getSegmentById(segmentId: string): TranscriptSegment | null {
+    const idx = this.segmentIndex.get(segmentId);
+    if (idx === undefined) return null;
+    return this.segments[idx] ?? null;
   }
 
   /**
@@ -75,20 +84,26 @@ export class TranscriptStore {
   }
 
   /**
-   * Register a callback that fires whenever the timeline changes (append or clear).
+   * Register a callback that fires whenever the timeline changes.
    * Returns an unsubscribe function; call it to stop receiving updates.
-   * Multiple listeners may be registered simultaneously.
    *
-   * @param callback - Receives the full ordered segment list on every change.
+   * @param listener - Receives the full ordered segment list on every change.
    * @returns Unsubscribe function.
    */
-  onUpdate(callback: (segments: TranscriptSegment[]) => void): () => void {
-    this.listeners.add(callback);
-    return () => this.listeners.delete(callback);
+  subscribe(listener: (segments: TranscriptSegment[]) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
   }
 
   private _notify(): void {
-    const snapshot = this.getAll();
+    const snapshot = this.getSegments();
     this.listeners.forEach((cb) => cb(snapshot));
+  }
+
+  private _rebuildIndex(): void {
+    this.segmentIndex.clear();
+    for (let i = 0; i < this.segments.length; i++) {
+      this.segmentIndex.set(this.segments[i].segmentId, i);
+    }
   }
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,3 +1,2 @@
 export { TranscriptStore } from './TranscriptStore';
 export { TranscriptExporter } from './TranscriptExporter';
-export type { TextExportOptions } from './TranscriptExporter';

--- a/src/ui/testing/MockTranscriptSource.ts
+++ b/src/ui/testing/MockTranscriptSource.ts
@@ -86,7 +86,7 @@ export class MockTranscriptSource {
         createdAtMs: now,
         replacesSegmentId: null,
       };
-      this.store.append(segment);
+      this.store.receiveSegment(segment);
       this.pendingPartialId = id;
       this.scheduleNext(FINAL_DELAY_MS);
     } else {
@@ -102,7 +102,7 @@ export class MockTranscriptSource {
         createdAtMs: now,
         replacesSegmentId: this.pendingPartialId,
       };
-      this.store.append(segment);
+      this.store.receiveSegment(segment);
       this.pendingPartialId = null;
       this.lineIdx++;
       this.scheduleNext(PARTIAL_INTERVAL_MS);


### PR DESCRIPTION
Closes #21
Closes #11

## What does this PR do?

Aligns store, audio-pipeline, and common model packages with the LLD spec. UI changes were dropped since #28 already covers them.

**store:** Renamed TranscriptStore methods to match LLD (`receiveSegment`, `getSegments`, `subscribe`, `getSegmentById`), added `segmentIndex` Map for O(1) partial→final lookups. Decoupled TranscriptExporter to accept `(segments, filePath)` and switched to `expo-file-system/next` File API. Also fixed `MockTranscriptSource` and its tests to use the new method names.

**audio-pipeline:** Made AudioChunker's `chunkDurationMs` and `sampleRateHz` configurable via constructor. Absorbed AudioChunker unit tests from the stale #22 branch.

**common:** Fixed `AudioFeatureChunk.featureType` union from `'landmarks'` to `'mel_spectrogram'`.

## Which package(s) does it touch?

- sozia.client.pipeline.audio
- sozia.client.store
- sozia.common.models

## How to test

```
npm run test
```

All 133 tests pass across 12 suites.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [ ] No sozia.common schema changes (or: both repos updated) — `featureType` changed, server repo needs matching update
- [x] Tested locally