### PR TITLE
feat(audio-pipeline): implement VoiceActivityDetector and AudioFeatureExtractor

### DIFF
--- a/__tests__/pipeline/audio/AudioFeatureExtractor.test.ts
+++ b/__tests__/pipeline/audio/AudioFeatureExtractor.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests — AudioFeatureExtractor
+ *
+ * Verifies lifecycle (init/teardown), chunk production from MFCCFrames,
+ * and null-safety for uninitialised or empty-input scenarios.
+ */
+
+import { AudioFeatureExtractor } from '../../../src/pipeline/audio/AudioFeatureExtractor';
+import type { MFCCFrame } from '../../../src/pipeline/audio/AudioPipeline';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeFrame(timestampMs: number, seed = 0): MFCCFrame {
+  return {
+    timestampMs,
+    coefficients: Array.from({ length: 13 }, (_, i) => seed + i * 0.1),
+    energy: -30 + seed,
+  };
+}
+
+function fakeFrames(count: number, startMs = 0): MFCCFrame[] {
+  return Array.from({ length: count }, (_, i) => fakeFrame(startMs + i * 25, i));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AudioFeatureExtractor', () => {
+  let extractor: AudioFeatureExtractor;
+
+  beforeEach(() => {
+    extractor = new AudioFeatureExtractor();
+  });
+
+  it('is not ready before init', () => {
+    expect(extractor.isReady()).toBe(false);
+  });
+
+  it('returns null when not initialised', () => {
+    const result = extractor.extract(fakeFrames(5));
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty input', () => {
+    extractor.init('session-1');
+    expect(extractor.extract([])).toBeNull();
+  });
+
+  it('becomes ready after init', () => {
+    extractor.init('session-1');
+    expect(extractor.isReady()).toBe(true);
+  });
+
+  it('produces a valid AudioFeatureChunk from frames', () => {
+    extractor.init('session-abc');
+    const input = fakeFrames(10, 100);
+    const chunk = extractor.extract(input);
+
+    expect(chunk).not.toBeNull();
+    expect(chunk!.sessionId).toBe('session-abc');
+    expect(chunk!.timestampMs).toBe(100);
+    expect(chunk!.features).toHaveLength(10);
+    expect(chunk!.features[0]).toHaveLength(13);
+    expect(chunk!.featureType).toBe('mfcc');
+    expect(chunk!.sampleRateHz).toBe(16000);
+    expect(chunk!.chunkDurationMs).toBeGreaterThan(0);
+  });
+
+  it('uses custom sample rate', () => {
+    const custom = new AudioFeatureExtractor(44100);
+    custom.init('s1');
+    const chunk = custom.extract(fakeFrames(5));
+    expect(chunk!.sampleRateHz).toBe(44100);
+  });
+
+  it('handles single-frame input', () => {
+    extractor.init('s1');
+    const chunk = extractor.extract([fakeFrame(500)]);
+
+    expect(chunk).not.toBeNull();
+    expect(chunk!.timestampMs).toBe(500);
+    expect(chunk!.features).toHaveLength(1);
+    expect(chunk!.chunkDurationMs).toBe(25); // fallback frame duration
+  });
+
+  it('becomes not ready after teardown', () => {
+    extractor.init('s1');
+    expect(extractor.isReady()).toBe(true);
+
+    extractor.teardown();
+    expect(extractor.isReady()).toBe(false);
+    expect(extractor.extract(fakeFrames(3))).toBeNull();
+  });
+
+  it('can be re-initialised after teardown', () => {
+    extractor.init('s1');
+    extractor.teardown();
+    extractor.init('s2');
+
+    const chunk = extractor.extract(fakeFrames(3));
+    expect(chunk).not.toBeNull();
+    expect(chunk!.sessionId).toBe('s2');
+  });
+});

--- a/__tests__/pipeline/audio/VoiceActivityDetector.test.ts
+++ b/__tests__/pipeline/audio/VoiceActivityDetector.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests — VoiceActivityDetector
+ *
+ * Verifies energy-based speech detection across sensitivity levels,
+ * edge cases (empty input, boundary thresholds), and sensitivity switching.
+ */
+
+import { VoiceActivityDetector } from '../../../src/pipeline/audio/VoiceActivityDetector';
+import type { MFCCFrame } from '../../../src/pipeline/audio/AudioPipeline';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function frame(energy: number, timestampMs = 0): MFCCFrame {
+  return {
+    timestampMs,
+    coefficients: Array.from({ length: 13 }, (_, i) => i * 0.1),
+    energy,
+  };
+}
+
+function frames(energies: number[]): MFCCFrame[] {
+  return energies.map((e, i) => frame(e, i * 25));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('VoiceActivityDetector', () => {
+  let vad: VoiceActivityDetector;
+
+  beforeEach(() => {
+    vad = new VoiceActivityDetector();
+  });
+
+  it('defaults to medium sensitivity', () => {
+    expect(vad.getSensitivity()).toBe('medium');
+  });
+
+  it('returns false for an empty chunk', () => {
+    expect(vad.isSpeechPresent([])).toBe(false);
+  });
+
+  it('detects speech when most frames have high energy (medium)', () => {
+    // medium threshold: energy > -40, ratio >= 0.4
+    const chunk = frames([-20, -25, -35, -50, -55]);
+    // 3 out of 5 above -40 → ratio 0.6 >= 0.4
+    expect(vad.isSpeechPresent(chunk)).toBe(true);
+  });
+
+  it('rejects silence when most frames have low energy (medium)', () => {
+    const chunk = frames([-50, -55, -60, -45, -48]);
+    // 0 out of 5 above -40 → ratio 0
+    expect(vad.isSpeechPresent(chunk)).toBe(false);
+  });
+
+  it('low sensitivity requires stronger signal', () => {
+    vad.setSensitivity('low');
+    // low threshold: energy > -30, ratio >= 0.6
+    const chunk = frames([-25, -28, -35, -40, -45]);
+    // 2 out of 5 above -30 → ratio 0.4 < 0.6
+    expect(vad.isSpeechPresent(chunk)).toBe(false);
+  });
+
+  it('low sensitivity accepts strong signal', () => {
+    vad.setSensitivity('low');
+    const chunk = frames([-10, -15, -20, -25, -45]);
+    // 4 out of 5 above -30 → ratio 0.8 >= 0.6
+    expect(vad.isSpeechPresent(chunk)).toBe(true);
+  });
+
+  it('high sensitivity triggers on quiet speech', () => {
+    vad.setSensitivity('high');
+    // high threshold: energy > -50, ratio >= 0.25
+    const chunk = frames([-45, -55, -60, -65]);
+    // 1 out of 4 above -50 → ratio 0.25 >= 0.25
+    expect(vad.isSpeechPresent(chunk)).toBe(true);
+  });
+
+  it('high sensitivity still rejects deep silence', () => {
+    vad.setSensitivity('high');
+    const chunk = frames([-55, -60, -70, -80]);
+    // 0 out of 4 above -50
+    expect(vad.isSpeechPresent(chunk)).toBe(false);
+  });
+
+  it('setSensitivity changes the active level', () => {
+    vad.setSensitivity('high');
+    expect(vad.getSensitivity()).toBe('high');
+    vad.setSensitivity('low');
+    expect(vad.getSensitivity()).toBe('low');
+  });
+
+  it('handles a single-frame chunk', () => {
+    const loud = frames([-20]);
+    const quiet = frames([-55]);
+    expect(vad.isSpeechPresent(loud)).toBe(true);
+    expect(vad.isSpeechPresent(quiet)).toBe(false);
+  });
+});

--- a/src/pipeline/audio/AudioFeatureExtractor.ts
+++ b/src/pipeline/audio/AudioFeatureExtractor.ts
@@ -1,0 +1,84 @@
+import type { AudioFeatureChunk } from '../../common/models';
+import type { MFCCFrame } from './AudioPipeline';
+
+/**
+ * Contract for any feature extraction stage in the pipeline.
+ * Each implementation converts raw input into a typed feature chunk
+ * suitable for transmission.
+ */
+export interface FeatureExtractor<TInput, TOutput> {
+  extract(rawInput: TInput): TOutput | null;
+  isReady(): boolean;
+}
+
+/**
+ * Converts a batch of MFCCFrames into an AudioFeatureChunk ready for
+ * transmission to the inference server.
+ *
+ * Implements the FeatureExtractor contract from LLD Section 3.2.3.
+ * Acts as the boundary between local audio processing and the network
+ * layer — raw audio never passes through this class, only anonymized
+ * numerical features.
+ *
+ * Collaborators: AudioChunker (provides frame batches),
+ *                TransmissionManager (consumes chunks).
+ */
+export class AudioFeatureExtractor
+  implements FeatureExtractor<MFCCFrame[], AudioFeatureChunk>
+{
+  private ready = false;
+  private sessionId = '';
+  private sampleRateHz: number;
+
+  constructor(sampleRateHz = 16000) {
+    this.sampleRateHz = sampleRateHz;
+  }
+
+  /**
+   * Initialise the extractor for a new session.
+   * Must be called before `extract()` will produce output.
+   */
+  init(sessionId: string): void {
+    this.sessionId = sessionId;
+    this.ready = true;
+  }
+
+  /**
+   * Release resources and mark the extractor as not ready.
+   */
+  teardown(): void {
+    this.ready = false;
+    this.sessionId = '';
+  }
+
+  /**
+   * Converts an array of MFCCFrames into a single AudioFeatureChunk.
+   *
+   * Returns null if the extractor has not been initialised or the input
+   * is empty — callers should silently skip null results.
+   *
+   * @param rawInput - Batch of MFCCFrames from a single chunker window.
+   */
+  extract(rawInput: MFCCFrame[]): AudioFeatureChunk | null {
+    if (!this.ready || rawInput.length === 0) return null;
+
+    const firstTimestamp = rawInput[0].timestampMs;
+    const lastTimestamp = rawInput[rawInput.length - 1].timestampMs;
+    const frameDuration = rawInput.length > 1
+      ? (lastTimestamp - firstTimestamp) / (rawInput.length - 1)
+      : 25; // fallback to default frame interval
+
+    return {
+      sessionId: this.sessionId,
+      timestampMs: firstTimestamp,
+      features: rawInput.map((f) => f.coefficients),
+      featureType: 'mfcc',
+      sampleRateHz: this.sampleRateHz,
+      chunkDurationMs: Math.round(rawInput.length * frameDuration),
+    };
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+}

--- a/src/pipeline/audio/VoiceActivityDetector.ts
+++ b/src/pipeline/audio/VoiceActivityDetector.ts
@@ -1,0 +1,63 @@
+import type { MFCCFrame } from './AudioPipeline';
+
+/**
+ * Energy-based voice activity detector that determines whether a chunk of
+ * audio frames contains speech.
+ *
+ * Uses the per-frame `energy` (dBFS) from MFCCFrames to classify chunks as
+ * speech or silence. A chunk is considered speech when the proportion of
+ * frames above the energy threshold exceeds a sensitivity-dependent ratio.
+ *
+ * Sensitivity levels adjust how aggressively the detector triggers:
+ *   - 'low'    — requires a strong signal; fewer false positives in noisy environments.
+ *   - 'medium' — balanced default.
+ *   - 'high'   — triggers on quieter speech; useful in controlled/quiet environments.
+ *
+ * Collaborators: AudioChunker (caller), AudioPipeline (frame source).
+ */
+export type SensitivityLevel = 'low' | 'medium' | 'high';
+
+const ENERGY_THRESHOLDS: Record<SensitivityLevel, number> = {
+  low: -30,
+  medium: -40,
+  high: -50,
+};
+
+const SPEECH_RATIO_THRESHOLDS: Record<SensitivityLevel, number> = {
+  low: 0.6,
+  medium: 0.4,
+  high: 0.25,
+};
+
+export class VoiceActivityDetector {
+  private sensitivity: SensitivityLevel = 'medium';
+
+  /**
+   * Determines whether the given chunk of frames contains speech.
+   *
+   * @param chunk - Array of MFCCFrames from a single AudioChunker window.
+   * @returns true if the chunk likely contains speech.
+   */
+  isSpeechPresent(chunk: MFCCFrame[]): boolean {
+    if (chunk.length === 0) return false;
+
+    const energyThreshold = ENERGY_THRESHOLDS[this.sensitivity];
+    const ratioThreshold = SPEECH_RATIO_THRESHOLDS[this.sensitivity];
+
+    const activeFrames = chunk.filter((f) => f.energy > energyThreshold).length;
+    return activeFrames / chunk.length >= ratioThreshold;
+  }
+
+  /**
+   * Adjusts detection sensitivity.
+   *
+   * @param level - 'low' (strict), 'medium' (default), or 'high' (permissive).
+   */
+  setSensitivity(level: SensitivityLevel): void {
+    this.sensitivity = level;
+  }
+
+  getSensitivity(): SensitivityLevel {
+    return this.sensitivity;
+  }
+}

--- a/src/pipeline/audio/index.ts
+++ b/src/pipeline/audio/index.ts
@@ -1,3 +1,7 @@
 export type { IAudioPipeline, MFCCFrame } from './AudioPipeline';
 export { ExpoAudioPipeline } from './ExpoAudioPipeline';
 export { AudioChunker } from './AudioChunker';
+export { VoiceActivityDetector } from './VoiceActivityDetector';
+export type { SensitivityLevel } from './VoiceActivityDetector';
+export { AudioFeatureExtractor } from './AudioFeatureExtractor';
+export type { FeatureExtractor } from './AudioFeatureExtractor';


### PR DESCRIPTION
Closes #35

## What does this PR do?

Fills in the two missing classes in `sozia.client.pipeline.audio` — the energy-based voice activity detector and the feature extractor that packages MFCCFrame batches into AudioFeatureChunks for transmission.

VoiceActivityDetector classifies frame chunks as speech or silence using per-frame dBFS energy. It has three sensitivity levels (low, medium, high) that control both the energy threshold and the required ratio of active frames. This way we can skip sending silent chunks to the server altogether.

AudioFeatureExtractor sits between the chunker and the transmission layer. It takes a batch of MFCCFrames and produces a single AudioFeatureChunk with the right session metadata, timestamps, and duration. Has a simple init/teardown lifecycle so it can be wired into session start/stop.

Both classes are exported from the audio pipeline barrel.

## Which package(s) does it touch?

- `sozia.client.pipeline.audio`

## How to test

- `npx jest __tests__/pipeline/audio/VoiceActivityDetector.test.ts`
- `npx jest __tests__/pipeline/audio/AudioFeatureExtractor.test.ts`
- Or just `npx jest` — all 154 tests pass, nothing broken.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally