### PR TITLE
fix(common): fixed syntax error in index.ts

### DIFF
--- a/src/common/models/index.ts
+++ b/src/common/models/index.ts
@@ -71,15 +71,9 @@ export interface AudioFeatureChunk {
   timestampMs: number;
   /** 2D array [T, D] — T temporal frames, D feature dimensions. T ≥ 1, D ≥ 1. */
   features: number[][];
-<<<<<<< feature/video-pipeline-landmark-extractor
   /** Must match the server's expected input format. */
   featureType: 'mfcc' | 'mel_spectrogram';
   /** Positive integer in Hertz (e.g., 16 000). */
-=======
-  /** Identifies the feature extraction method. */
-  featureType: 'mfcc' | 'mel_spectrogram';
-  /** Sample rate of the underlying audio signal in Hz. */
->>>>>>> dev
   sampleRateHz: number;
   /** Duration in milliseconds. > 0; typical 500–2 000 ms. */
   chunkDurationMs: number;


### PR DESCRIPTION
## What does this PR do?

- Fixes syntax error caused by resolve conflict lines in models/index.ts

## Which package(s) does it touch?

- sozia.client.common

## How to test

- `npm run check`

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [ ] Added/updated tests (if applicable)
- [ ] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally