### PR TITLE
feat(audio-pipeline): wire VAD and feature extractor into AudioChunker

### DIFF
--- a/__tests__/config/DiagnosticsLogger.test.ts
+++ b/__tests__/config/DiagnosticsLogger.test.ts
@@ -34,6 +34,7 @@ function makeConfig(enabled: boolean): IConfigurationManager {
     serverUrl: 'wss://...',
     maxReconnectAttempts: 5,
     diagnosticsEnabled: enabled,
+    vadSensitivity: 'medium',
   };
 
   return {

--- a/__tests__/pipeline/audio/AudioChunker.test.ts
+++ b/__tests__/pipeline/audio/AudioChunker.test.ts
@@ -11,6 +11,8 @@
  */
 
 import { AudioChunker } from '../../../src/pipeline/audio/AudioChunker';
+import { VoiceActivityDetector } from '../../../src/pipeline/audio/VoiceActivityDetector';
+import { AudioFeatureExtractor } from '../../../src/pipeline/audio/AudioFeatureExtractor';
 import type { MFCCFrame } from '../../../src/pipeline/audio/AudioPipeline';
 import type { AudioFeatureChunk } from '../../../src/common/models';
 
@@ -212,5 +214,95 @@ describe('AudioChunker', () => {
 
     expect(chunks).toHaveLength(1);
     expect(chunks[0].sessionId).toBe('session-2');
+  });
+
+  // -- VAD + FeatureExtractor wiring ---------------------------------------
+
+  describe('VAD gating', () => {
+    it('drops chunks whose frames are classified as silence', () => {
+      const silentVad: VoiceActivityDetector = {
+        isSpeechPresent: () => false,
+        setSensitivity: () => {},
+        getSensitivity: () => 'medium',
+      } as unknown as VoiceActivityDetector;
+
+      const silentChunker = new AudioChunker(500, 16000, silentVad);
+      silentChunker.start('session-silent');
+
+      const chunks: AudioFeatureChunk[] = [];
+      silentChunker.onChunk((c) => chunks.push(c));
+
+      pushFrames(silentChunker, 20);
+
+      expect(chunks).toHaveLength(0);
+      silentChunker.stop();
+    });
+
+    it('emits when VAD reports speech present', () => {
+      const speechVad: VoiceActivityDetector = {
+        isSpeechPresent: () => true,
+        setSensitivity: () => {},
+        getSensitivity: () => 'medium',
+      } as unknown as VoiceActivityDetector;
+
+      const speechChunker = new AudioChunker(500, 16000, speechVad);
+      speechChunker.start('session-speech');
+
+      const chunks: AudioFeatureChunk[] = [];
+      speechChunker.onChunk((c) => chunks.push(c));
+
+      pushFrames(speechChunker, 20);
+
+      expect(chunks).toHaveLength(1);
+      speechChunker.stop();
+    });
+
+    it('exposes the internal VAD for sensitivity configuration', () => {
+      const vad = new VoiceActivityDetector();
+      const c = new AudioChunker(500, 16000, vad);
+
+      expect(c.getVoiceActivityDetector()).toBe(vad);
+    });
+  });
+
+  describe('feature extractor wiring', () => {
+    it('delegates chunk construction to the injected extractor', () => {
+      const extractor = new AudioFeatureExtractor();
+      const extractSpy = jest.spyOn(extractor, 'extract');
+
+      const c = new AudioChunker(500, 16000, new VoiceActivityDetector(), extractor);
+      c.start('session-extract');
+
+      const chunks: AudioFeatureChunk[] = [];
+      c.onChunk((ch) => chunks.push(ch));
+
+      pushFrames(c, 20);
+
+      expect(extractSpy).toHaveBeenCalledTimes(1);
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].sessionId).toBe('session-extract');
+      c.stop();
+    });
+
+    it('emits nothing before start() because the extractor is not ready', () => {
+      const c = new AudioChunker();
+      const chunks: AudioFeatureChunk[] = [];
+      c.onChunk((ch) => chunks.push(ch));
+
+      pushFrames(c, 20);
+
+      expect(chunks).toHaveLength(0);
+    });
+
+    it('tears down the extractor on stop()', () => {
+      const extractor = new AudioFeatureExtractor();
+      const c = new AudioChunker(500, 16000, new VoiceActivityDetector(), extractor);
+
+      c.start('session-teardown');
+      expect(extractor.isReady()).toBe(true);
+
+      c.stop();
+      expect(extractor.isReady()).toBe(false);
+    });
   });
 });

--- a/src/config/Configuration.ts
+++ b/src/config/Configuration.ts
@@ -12,6 +12,7 @@ export interface AppConfig {
   serverUrl: string;
   maxReconnectAttempts: number;
   diagnosticsEnabled: boolean;
+  vadSensitivity: 'low' | 'medium' | 'high';
 }
 
 export interface IConfigurationManager {
@@ -38,6 +39,7 @@ const DEFAULT_CONFIG: AppConfig = {
   serverUrl: 'wss://...',
   maxReconnectAttempts: 5,
   diagnosticsEnabled: false,
+  vadSensitivity: 'medium',
 };
 
 function getBrowserStorage(): KeyValueStorage | null {
@@ -76,6 +78,10 @@ function mergeWithDefaults(raw: unknown): AppConfig {
       : DEFAULT_CONFIG.serverUrl,
     maxReconnectAttempts: clampNumber(input.maxReconnectAttempts, DEFAULT_CONFIG.maxReconnectAttempts, 0, 50),
     diagnosticsEnabled: input.diagnosticsEnabled === true,
+    vadSensitivity:
+      input.vadSensitivity === 'low' || input.vadSensitivity === 'high'
+        ? input.vadSensitivity
+        : 'medium',
   };
 }
 

--- a/src/pipeline/audio/AudioChunker.ts
+++ b/src/pipeline/audio/AudioChunker.ts
@@ -1,5 +1,7 @@
 import type { AudioFeatureChunk } from '../../common/models';
 import type { MFCCFrame } from './AudioPipeline';
+import { AudioFeatureExtractor } from './AudioFeatureExtractor';
+import { VoiceActivityDetector } from './VoiceActivityDetector';
 
 /** Duration in ms of each captured frame — must match ExpoAudioPipeline.FRAME_INTERVAL_MS. */
 const FRAME_INTERVAL_MS = 25;
@@ -7,6 +9,11 @@ const FRAME_INTERVAL_MS = 25;
 /**
  * Accumulates MFCCFrames from the audio pipeline and emits AudioFeatureChunks
  * at regular intervals for transmission to the inference server.
+ *
+ * The chunker owns the VAD and feature-extractor stages: each completed frame
+ * batch is first gated by VoiceActivityDetector — silent windows are dropped
+ * before they ever become chunks — and then passed through AudioFeatureExtractor
+ * to produce the transmission-ready AudioFeatureChunk.
  *
  * Collaborators: ExpoAudioPipeline (produces frames), TransmissionManager (consumes chunks).
  *
@@ -26,22 +33,32 @@ export class AudioChunker {
 
   private framesPerChunk: number;
   private buffer: MFCCFrame[] = [];
-  private sessionId = '';
   private listeners = new Set<(chunk: AudioFeatureChunk) => void>();
+  private vad: VoiceActivityDetector;
+  private extractor: AudioFeatureExtractor;
 
   /**
    * @param chunkDurationMs - Duration of each chunk (default: 500 ms).
    * @param sampleRateHz - Audio sample rate (default: 16 000 Hz).
+   * @param vad - Voice activity detector used to drop silent windows.
+   * @param extractor - Feature extractor that builds the AudioFeatureChunk.
    */
-  constructor(chunkDurationMs = 500, sampleRateHz = 16000) {
+  constructor(
+    chunkDurationMs = 500,
+    sampleRateHz = 16000,
+    vad: VoiceActivityDetector = new VoiceActivityDetector(),
+    extractor: AudioFeatureExtractor = new AudioFeatureExtractor(sampleRateHz),
+  ) {
     this.chunkDurationMs = chunkDurationMs;
     this.sampleRateHz = sampleRateHz;
     this.framesPerChunk = Math.round(chunkDurationMs / FRAME_INTERVAL_MS);
+    this.vad = vad;
+    this.extractor = extractor;
   }
 
   start(sessionId: string): void {
-    this.sessionId = sessionId;
     this.buffer = [];
+    this.extractor.init(sessionId);
   }
 
   push(frame: MFCCFrame): void {
@@ -53,7 +70,7 @@ export class AudioChunker {
 
   stop(): void {
     this.buffer = [];
-    this.sessionId = '';
+    this.extractor.teardown();
   }
 
   /**
@@ -65,18 +82,18 @@ export class AudioChunker {
     return () => this.listeners.delete(callback);
   }
 
+  /** Exposes the internal VAD so higher layers can adjust sensitivity from Configuration. */
+  getVoiceActivityDetector(): VoiceActivityDetector {
+    return this.vad;
+  }
+
   // ---------------------------------------------------------------------------
 
   private _flush(): void {
     const frames = this.buffer.splice(0, this.framesPerChunk);
-    const chunk: AudioFeatureChunk = {
-      sessionId: this.sessionId,
-      timestampMs: frames[0].timestampMs,
-      features: frames.map((f) => f.coefficients),
-      featureType: 'mfcc',
-      sampleRateHz: this.sampleRateHz,
-      chunkDurationMs: frames.length * FRAME_INTERVAL_MS,
-    };
+    if (!this.vad.isSpeechPresent(frames)) return;
+    const chunk = this.extractor.extract(frames);
+    if (chunk === null) return;
     this.listeners.forEach((cb) => cb(chunk));
   }
 }

--- a/src/ui/controller/SessionController.tsx
+++ b/src/ui/controller/SessionController.tsx
@@ -81,9 +81,13 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
   const deviceManager = useRef(new DeviceManager(new ExpoDeviceEnumerator(), audioPipeline.current));
   const config = useRef<IConfigurationManager>(new Configuration());
 
-  // Load persisted configuration on mount.
+  // Load persisted configuration on mount, then apply settings that gate pipeline behaviour.
   useEffect(() => {
-    void config.current.load();
+    void config.current.load().then(() => {
+      audioChunker.current
+        .getVoiceActivityDetector()
+        .setSensitivity(config.current.get('vadSensitivity'));
+    });
   }, []);
 
   const stateRef = useRef(state);


### PR DESCRIPTION
## What does this PR do?

Hooks `VoiceActivityDetector` and `AudioFeatureExtractor` — both added in #34 but previously unused — into the audio capture path. `AudioChunker._flush()` now gates each completed frame batch through the VAD (silent windows are dropped before they ever become chunks) and delegates chunk construction to `AudioFeatureExtractor.extract()` instead of building the `AudioFeatureChunk` inline, which also removes the duplicated chunk-construction logic that had been living in two places.

Adds a `vadSensitivity` key to `Configuration` (defaults to `'medium'`, clamped in `mergeWithDefaults`) and applies it from `SessionController` after config load, so the sensitivity persists across sessions. The Settings UI for picking the level will come in a follow-up.

Closes #40.

## Which package(s) does it touch?

- `sozia.client.pipeline.audio`
- `sozia.client.config`
- `sozia.client.ui` (SessionController wiring only)

## How to test

- `npx jest __tests__/pipeline/audio` — 7 new AudioChunker cases cover VAD gating (both outcomes), extractor delegation via spy, and extractor teardown on stop.
- `npx jest` — full suite, 167/167 passing.
- `npx tsc --noEmit` — clean.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally