### PR TITLE
refactor(audio-pipeline,ui): move AudioChunker ownership into ExpoAudioPipeline

### DIFF
--- a/__tests__/device/DeviceManager.test.ts
+++ b/__tests__/device/DeviceManager.test.ts
@@ -21,8 +21,8 @@ import { Audio } from 'expo-av';
 import { DeviceManager } from '../../src/device/DeviceManager';
 import type { IDeviceEnumerator } from '../../src/device/DeviceEnumerator';
 import type { DeviceHandle } from '../../src/device/DeviceHandle';
-import type { IAudioPipeline, MFCCFrame } from '../../src/pipeline/audio';
-import type { PipelineHealth } from '../../src/common/models';
+import type { IAudioPipeline, MFCCFrame, SensitivityLevel } from '../../src/pipeline/audio';
+import type { AudioFeatureChunk, PipelineHealth } from '../../src/common/models';
 
 const mockRequestPermissions = Audio.requestPermissionsAsync as jest.Mock;
 
@@ -96,6 +96,15 @@ class MockAudioPipeline implements IAudioPipeline {
 
   onFrame(_callback: (frame: MFCCFrame) => void): () => void {
     return () => {};
+  }
+
+  onChunk(_callback: (chunk: AudioFeatureChunk) => void): () => void {
+    return () => {};
+  }
+
+  setVadSensitivity(_level: SensitivityLevel): void {
+    // no-op for the device manager mock — sensitivity plumbing is exercised
+    // in the audio pipeline tests, not here.
   }
 }
 

--- a/__tests__/pipeline/audio/AudioChunker.test.ts
+++ b/__tests__/pipeline/audio/AudioChunker.test.ts
@@ -216,6 +216,20 @@ describe('AudioChunker', () => {
     expect(chunks[0].sessionId).toBe('session-2');
   });
 
+  it('drops all listeners when clearListeners() is called', () => {
+    let received = 0;
+    chunker.onChunk(() => {
+      received += 1;
+    });
+
+    pushFrames(chunker, 20);
+    expect(received).toBe(1);
+
+    chunker.clearListeners();
+    pushFrames(chunker, 20, 20 * 25);
+    expect(received).toBe(1);
+  });
+
   // -- VAD + FeatureExtractor wiring ---------------------------------------
 
   describe('VAD gating', () => {

--- a/__tests__/pipeline/audio/AudioPipeline.test.ts
+++ b/__tests__/pipeline/audio/AudioPipeline.test.ts
@@ -13,7 +13,8 @@
  */
 
 import type { IAudioPipeline, MFCCFrame } from '../../../src/pipeline/audio';
-import type { PipelineHealth } from '../../../src/common/models';
+import type { SensitivityLevel } from '../../../src/pipeline/audio';
+import type { AudioFeatureChunk, PipelineHealth } from '../../../src/common/models';
 
 // ---------------------------------------------------------------------------
 // MockAudioPipeline — a minimal, synchronous stand-in used only in tests.
@@ -23,7 +24,9 @@ class MockAudioPipeline implements IAudioPipeline {
   private sessionId = '';
   private available = false;
   private lastUpdatedMs = 0;
-  private listeners: Set<(frame: MFCCFrame) => void> = new Set();
+  private frameListeners: Set<(frame: MFCCFrame) => void> = new Set();
+  private chunkListeners: Set<(chunk: AudioFeatureChunk) => void> = new Set();
+  private sensitivity: SensitivityLevel = 'medium';
 
   async start(sessionId: string): Promise<void> {
     this.sessionId = sessionId;
@@ -42,7 +45,8 @@ class MockAudioPipeline implements IAudioPipeline {
   stop(): void {
     this.sessionId = '';
     this.available = false;
-    this.listeners.clear();
+    this.frameListeners.clear();
+    this.chunkListeners.clear();
   }
 
   getHealth(): PipelineHealth {
@@ -58,13 +62,32 @@ class MockAudioPipeline implements IAudioPipeline {
   }
 
   onFrame(callback: (frame: MFCCFrame) => void): () => void {
-    this.listeners.add(callback);
-    return () => this.listeners.delete(callback);
+    this.frameListeners.add(callback);
+    return () => this.frameListeners.delete(callback);
+  }
+
+  onChunk(callback: (chunk: AudioFeatureChunk) => void): () => void {
+    this.chunkListeners.add(callback);
+    return () => this.chunkListeners.delete(callback);
+  }
+
+  setVadSensitivity(level: SensitivityLevel): void {
+    this.sensitivity = level;
   }
 
   /** Test helper: emit a frame to all registered listeners. */
   _emit(frame: MFCCFrame): void {
-    this.listeners.forEach((cb) => cb(frame));
+    this.frameListeners.forEach((cb) => cb(frame));
+  }
+
+  /** Test helper: read the current sensitivity state (test assertions only). */
+  _getSensitivity(): SensitivityLevel {
+    return this.sensitivity;
+  }
+
+  /** Test helper: emit a chunk to all registered chunk listeners. */
+  _emitChunk(chunk: AudioFeatureChunk): void {
+    this.chunkListeners.forEach((cb) => cb(chunk));
   }
 }
 
@@ -250,5 +273,83 @@ describe('IAudioPipeline.onFrame()', () => {
     pipeline._emit(makeMockFrame());
 
     expect(received).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chunk subscription and VAD sensitivity contract
+// ---------------------------------------------------------------------------
+
+function makeMockChunk(): AudioFeatureChunk {
+  return {
+    sessionId: 'session-001',
+    timestampMs: 0,
+    features: Array.from({ length: 20 }, () =>
+      Array.from({ length: 13 }, (_, i) => i * 0.1),
+    ),
+    featureType: 'mfcc',
+    sampleRateHz: 16000,
+    chunkDurationMs: 500,
+  };
+}
+
+describe('IAudioPipeline.onChunk()', () => {
+  let pipeline: MockAudioPipeline;
+
+  beforeEach(() => {
+    pipeline = new MockAudioPipeline();
+  });
+
+  it('returns an unsubscribe function', async () => {
+    await pipeline.start('session-001');
+    const unsub = pipeline.onChunk(() => {});
+    expect(typeof unsub).toBe('function');
+    unsub();
+  });
+
+  it('delivers emitted chunks to registered listeners', async () => {
+    await pipeline.start('session-001');
+    const received: AudioFeatureChunk[] = [];
+    pipeline.onChunk((c) => received.push(c));
+
+    const chunk = makeMockChunk();
+    pipeline._emitChunk(chunk);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual(chunk);
+  });
+
+  it('stops delivering chunks after unsubscribe', async () => {
+    await pipeline.start('session-001');
+    const received: AudioFeatureChunk[] = [];
+    const unsub = pipeline.onChunk((c) => received.push(c));
+
+    pipeline._emitChunk(makeMockChunk());
+    unsub();
+    pipeline._emitChunk(makeMockChunk());
+
+    expect(received).toHaveLength(1);
+  });
+
+  it('clears chunk listeners on stop()', async () => {
+    await pipeline.start('session-001');
+    const received: AudioFeatureChunk[] = [];
+    pipeline.onChunk((c) => received.push(c));
+
+    pipeline.stop();
+    pipeline._emitChunk(makeMockChunk());
+
+    expect(received).toHaveLength(0);
+  });
+});
+
+describe('IAudioPipeline.setVadSensitivity()', () => {
+  it('records the sensitivity level the caller passes in', () => {
+    const pipeline = new MockAudioPipeline();
+    pipeline.setVadSensitivity('high');
+    expect(pipeline._getSensitivity()).toBe('high');
+
+    pipeline.setVadSensitivity('low');
+    expect(pipeline._getSensitivity()).toBe('low');
   });
 });

--- a/src/pipeline/audio/AudioChunker.ts
+++ b/src/pipeline/audio/AudioChunker.ts
@@ -87,6 +87,11 @@ export class AudioChunker {
     return this.vad;
   }
 
+  /** Removes all chunk listeners. Used by the owning pipeline when tearing down. */
+  clearListeners(): void {
+    this.listeners.clear();
+  }
+
   // ---------------------------------------------------------------------------
 
   private _flush(): void {

--- a/src/pipeline/audio/AudioPipeline.ts
+++ b/src/pipeline/audio/AudioPipeline.ts
@@ -1,4 +1,5 @@
-import type { PipelineHealth } from '../../common/models';
+import type { AudioFeatureChunk, PipelineHealth } from '../../common/models';
+import type { SensitivityLevel } from './VoiceActivityDetector';
 
 /**
  * A single frame of extracted audio features, produced by the audio pipeline
@@ -73,4 +74,22 @@ export interface IAudioPipeline {
    * Multiple listeners may be registered simultaneously.
    */
   onFrame(callback: (frame: MFCCFrame) => void): () => void;
+
+  /**
+   * Register a callback to receive assembled AudioFeatureChunks — the
+   * transmission-ready output of the VAD + feature-extraction stages that
+   * the pipeline drives internally. Silent windows are gated out before
+   * reaching this callback.
+   *
+   * Returns an unsubscribe function; multiple listeners may be registered
+   * simultaneously. Subscriptions are cleared by stop().
+   */
+  onChunk(callback: (chunk: AudioFeatureChunk) => void): () => void;
+
+  /**
+   * Adjust the sensitivity of the internal voice activity detector so
+   * callers can wire Configuration.vadSensitivity through a single entry
+   * point on the pipeline rather than reaching into its internals.
+   */
+  setVadSensitivity(level: SensitivityLevel): void;
 }

--- a/src/pipeline/audio/ExpoAudioPipeline.ts
+++ b/src/pipeline/audio/ExpoAudioPipeline.ts
@@ -1,7 +1,9 @@
 import { Audio } from 'expo-av';
 
-import type { PipelineHealth } from '../../common/models';
+import type { AudioFeatureChunk, PipelineHealth } from '../../common/models';
 import type { IAudioPipeline, MFCCFrame } from './AudioPipeline';
+import { AudioChunker } from './AudioChunker';
+import type { SensitivityLevel } from './VoiceActivityDetector';
 
 const FRAME_INTERVAL_MS = 25; // 40 Hz frame rate
 const NUM_MFCC_COEFFICIENTS = 13;
@@ -27,10 +29,21 @@ export class ExpoAudioPipeline implements IAudioPipeline {
 
   private recording: Audio.Recording | null = null;
   private frameTimer: ReturnType<typeof setInterval> | null = null;
-  private listeners = new Set<(frame: MFCCFrame) => void>();
+  private frameListeners = new Set<(frame: MFCCFrame) => void>();
 
   /** Most recent dBFS metering value from expo-av status updates. */
   private lastMeteringDbfs = NOISE_FLOOR_DBFS;
+
+  /**
+   * Internal chunker that batches MFCC frames into AudioFeatureChunks.
+   * The chunker owns its own VAD and feature extractor; the pipeline drives
+   * it on every extracted frame and exposes its output via onChunk().
+   */
+  private readonly chunker: AudioChunker;
+
+  constructor(chunker: AudioChunker = new AudioChunker()) {
+    this.chunker = chunker;
+  }
 
   async start(sessionId: string): Promise<void> {
     if (this.available || this.paused) return;
@@ -57,6 +70,7 @@ export class ExpoAudioPipeline implements IAudioPipeline {
     this.sessionStartMs = Date.now();
     this.available = true;
     this.paused = false;
+    this.chunker.start(sessionId);
 
     this._startFrameTimer();
   }
@@ -80,7 +94,9 @@ export class ExpoAudioPipeline implements IAudioPipeline {
 
   stop(): void {
     this._stopFrameTimer();
-    this.listeners.clear();
+    this.frameListeners.clear();
+    this.chunker.clearListeners();
+    this.chunker.stop();
     this.available = false;
     this.paused = false;
     this.sessionId = '';
@@ -104,8 +120,16 @@ export class ExpoAudioPipeline implements IAudioPipeline {
   }
 
   onFrame(callback: (frame: MFCCFrame) => void): () => void {
-    this.listeners.add(callback);
-    return () => this.listeners.delete(callback);
+    this.frameListeners.add(callback);
+    return () => this.frameListeners.delete(callback);
+  }
+
+  onChunk(callback: (chunk: AudioFeatureChunk) => void): () => void {
+    return this.chunker.onChunk(callback);
+  }
+
+  setVadSensitivity(level: SensitivityLevel): void {
+    this.chunker.getVoiceActivityDetector().setSensitivity(level);
   }
 
   // ---------------------------------------------------------------------------
@@ -117,7 +141,8 @@ export class ExpoAudioPipeline implements IAudioPipeline {
       const frame = this._extractFrame();
       this.lastUpdatedMs = frame.timestampMs;
       this.currentSnr = Math.max(0, this.lastMeteringDbfs - NOISE_FLOOR_DBFS);
-      this.listeners.forEach((cb) => cb(frame));
+      this.chunker.push(frame);
+      this.frameListeners.forEach((cb) => cb(frame));
     }, FRAME_INTERVAL_MS);
   }
 

--- a/src/ui/controller/SessionController.tsx
+++ b/src/ui/controller/SessionController.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useR
 
 import { ModalityPath, SessionState, type PipelineHealth } from '../../common/models';
 import type { DeviceHandle } from '../../device';
-import { AudioChunker, ExpoAudioPipeline } from '../../pipeline/audio';
+import { ExpoAudioPipeline } from '../../pipeline/audio';
 import { DeviceManager, ExpoDeviceEnumerator } from '../../device';
 import { TranscriptStore } from '../../store';
 import { Configuration, type IConfigurationManager } from '../../config';
@@ -72,21 +72,18 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
 
   const store = useMemo(() => new TranscriptStore(), []);
 
-  // Audio pipeline, chunker, and device manager — stable across renders, one instance per provider.
+  // Audio pipeline and device manager — stable across renders, one instance per provider.
   // audioPipeline.current is safe to pass here: useRef returns the same MutableRefObject on every
   // render, so .current at construction time refers to the single ExpoAudioPipeline instance that
   // DeviceManager and SessionController both hold — no stale-closure risk.
   const audioPipeline = useRef(new ExpoAudioPipeline());
-  const audioChunker = useRef(new AudioChunker());
   const deviceManager = useRef(new DeviceManager(new ExpoDeviceEnumerator(), audioPipeline.current));
   const config = useRef<IConfigurationManager>(new Configuration());
 
   // Load persisted configuration on mount, then apply settings that gate pipeline behaviour.
   useEffect(() => {
     void config.current.load().then(() => {
-      audioChunker.current
-        .getVoiceActivityDetector()
-        .setSensitivity(config.current.get('vadSensitivity'));
+      audioPipeline.current.setVadSensitivity(config.current.get('vadSensitivity'));
     });
   }, []);
 
@@ -140,8 +137,6 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
         if (savedMicId) deviceManager.current.selectMicrophone(savedMicId);
         await deviceManager.current.activateMicrophone();
         await deviceManager.current.startAudioPipeline(newSessionId);
-        audioChunker.current.start(newSessionId);
-        audioPipeline.current.onFrame((frame) => audioChunker.current.push(frame));
       } else if (path === ModalityPath.SIGN) {
         const savedCameraId = config.current.get('selectedCameraId');
         if (savedCameraId) deviceManager.current.selectCamera(savedCameraId);
@@ -173,7 +168,6 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
 
   const stopSession = useCallback(() => {
     deviceManager.current.stopAllPipelines();
-    audioChunker.current.stop();
     setState(SessionState.IDLE);
     setSessionId(null);
     setActivePath(null);


### PR DESCRIPTION
## What does this PR do?

Moves the `AudioChunker`, `VoiceActivityDetector` and `AudioFeatureExtractor` stages inside `ExpoAudioPipeline` so they stop leaking into `SessionController`. `IAudioPipeline` gains two new entry points — `onChunk(cb)` for downstream consumers to subscribe to assembled `AudioFeatureChunk`s, and `setVadSensitivity(level)` so `Configuration.vadSensitivity` can be applied through a single pipeline call instead of the controller reaching into a standalone chunker instance.

With the refactor in place, `SessionController` no longer imports or holds an `AudioChunker`, which brings its attributes back in line with LLD Section 3.2.1 (`sessionId`, `state`, `activePath`, `deviceManager`, `transmissionManager`, `transcriptStore`, `config` — no pipeline internals). The frame-to-chunk wiring that previously lived in `startSession` moves into `ExpoAudioPipeline._startFrameTimer`, and `stopSession` no longer has to coordinate a separate chunker lifecycle.

This unblocks #45: once it rebases on top of this, `DeviceManager.onAudioChunk` can delegate directly to `audioPipeline.onChunk(cb)` instead of casting `IAudioPipeline` to an interface with an optional `onChunk` and silently returning a no-op.

Closes #47.

## Which package(s) does it touch?

- `sozia.client.pipeline.audio`
- `sozia.client.ui` (SessionController only)

## How to test

- `npx jest` — 173/173 passing. New coverage: `AudioChunker.clearListeners`, `IAudioPipeline.onChunk` contract (subscribe / unsubscribe / stop-clears), and `IAudioPipeline.setVadSensitivity` contract.
- `npx tsc --noEmit` — clean.
- `npm run lint` — clean.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally