### PR TITLE
refactor(audio-pipeline,ui): align audio pipeline wiring with LLD §3.2.3

### DIFF
--- a/__tests__/device/DeviceManager.test.ts
+++ b/__tests__/device/DeviceManager.test.ts
@@ -28,9 +28,14 @@ import { Camera as ExpoCamera } from 'expo-camera';
 import { DeviceManager } from '../../src/device/DeviceManager';
 import type { IDeviceEnumerator } from '../../src/device/DeviceEnumerator';
 import type { DeviceHandle } from '../../src/device/DeviceHandle';
-import type { IAudioPipeline, MFCCFrame } from '../../src/pipeline/audio';
+import type {
+  IAudioPipeline,
+  MFCCFrame,
+  RawAudioHandle,
+  SensitivityLevel,
+} from '../../src/pipeline/audio';
 import type { IVideoPipeline, RawMediaHandle } from '../../src/pipeline/video';
-import type { AudioFeatureChunk, PipelineHealth } from '../../src/common/models';
+import type { PipelineHealth } from '../../src/common/models';
 import type { TransmissionManager } from '../../src/transmission/TransmissionManager';
 
 const mockRequestPermissions = Audio.requestPermissionsAsync as jest.Mock;
@@ -69,13 +74,20 @@ class MockAudioPipeline implements IAudioPipeline {
   private available = false;
   startCalled = false;
   startCalledWith = '';
+  startCalledWithTx: TransmissionManager | undefined = undefined;
   stopCalled = false;
+  lastVadSensitivity: SensitivityLevel | null = null;
 
-  async start(sessionId: string): Promise<void> {
+  async start(
+    sessionId: string,
+    _micHandle: RawAudioHandle = {},
+    tx?: TransmissionManager,
+  ): Promise<void> {
     this.sessionId = sessionId;
     this.available = true;
     this.startCalled = true;
     this.startCalledWith = sessionId;
+    this.startCalledWithTx = tx;
   }
 
   pause(): void {
@@ -108,8 +120,8 @@ class MockAudioPipeline implements IAudioPipeline {
     return () => {};
   }
 
-  onChunk(_callback: (chunk: AudioFeatureChunk) => void): () => void {
-    return () => {};
+  setVadSensitivity(level: SensitivityLevel): void {
+    this.lastVadSensitivity = level;
   }
 }
 
@@ -339,6 +351,17 @@ describe('DeviceManager.startAudioPipeline()', () => {
     expect(pipeline.startCalledWith).toBe('sess-abc');
   });
 
+  it('TP-CLIENT-DEVICE-005d: forwards the TransmissionManager to the pipeline', async () => {
+    const pipeline = new MockAudioPipeline();
+    const manager = new DeviceManager(new MockDeviceEnumerator(), pipeline);
+    await manager.activateMicrophone();
+    const fakeTx = { sendFeatures: () => {} } as unknown as TransmissionManager;
+
+    await manager.startAudioPipeline('sess-tx', {}, fakeTx);
+
+    expect(pipeline.startCalledWithTx).toBe(fakeTx);
+  });
+
   it('TP-CLIENT-DEVICE-005b: throws when microphone has not been activated', async () => {
     const pipeline = new MockAudioPipeline();
     const manager = new DeviceManager(new MockDeviceEnumerator(), pipeline);
@@ -460,6 +483,27 @@ describe('DeviceManager.stopAllPipelines()', () => {
     manager.stopAllPipelines();
 
     expect(manager.isMicrophoneAvailable()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-DEVICE-010: setAudioVadSensitivity()
+// ---------------------------------------------------------------------------
+
+describe('DeviceManager.setAudioVadSensitivity()', () => {
+  it('TP-CLIENT-DEVICE-010a: delegates to the audio pipeline when configured', () => {
+    const pipeline = new MockAudioPipeline();
+    const manager = new DeviceManager(new MockDeviceEnumerator(), pipeline);
+
+    manager.setAudioVadSensitivity('high');
+
+    expect(pipeline.lastVadSensitivity).toBe('high');
+  });
+
+  it('TP-CLIENT-DEVICE-010b: is a no-op when no audio pipeline is configured', () => {
+    const manager = new DeviceManager(new MockDeviceEnumerator());
+
+    expect(() => manager.setAudioVadSensitivity('low')).not.toThrow();
   });
 });
 

--- a/__tests__/pipeline/audio/AudioPipeline.test.ts
+++ b/__tests__/pipeline/audio/AudioPipeline.test.ts
@@ -12,8 +12,9 @@
  * Test plan reference: TP-CLIENT-AUDIO-001 through TP-CLIENT-AUDIO-008
  */
 
-import type { IAudioPipeline, MFCCFrame } from '../../../src/pipeline/audio';
-import type { PipelineHealth } from '../../../src/common/models';
+import type { IAudioPipeline, MFCCFrame, RawAudioHandle, SensitivityLevel } from '../../../src/pipeline/audio';
+import type { AudioFeatureChunk, PipelineHealth } from '../../../src/common/models';
+import type { TransmissionManager } from '../../../src/transmission/TransmissionManager';
 
 // ---------------------------------------------------------------------------
 // MockAudioPipeline — a minimal, synchronous stand-in used only in tests.
@@ -24,11 +25,18 @@ class MockAudioPipeline implements IAudioPipeline {
   private available = false;
   private lastUpdatedMs = 0;
   private listeners: Set<(frame: MFCCFrame) => void> = new Set();
+  lastStartArgs: { sessionId: string; micHandle: RawAudioHandle; tx: TransmissionManager | undefined } | null = null;
+  lastVadSensitivity: SensitivityLevel | null = null;
 
-  async start(sessionId: string): Promise<void> {
+  async start(
+    sessionId: string,
+    micHandle: RawAudioHandle = {},
+    tx?: TransmissionManager,
+  ): Promise<void> {
     this.sessionId = sessionId;
     this.available = true;
     this.lastUpdatedMs = Date.now();
+    this.lastStartArgs = { sessionId, micHandle, tx };
   }
 
   pause(): void {
@@ -62,10 +70,24 @@ class MockAudioPipeline implements IAudioPipeline {
     return () => this.listeners.delete(callback);
   }
 
+  setVadSensitivity(level: SensitivityLevel): void {
+    this.lastVadSensitivity = level;
+  }
+
   /** Test helper: emit a frame to all registered listeners. */
   _emit(frame: MFCCFrame): void {
     this.listeners.forEach((cb) => cb(frame));
   }
+}
+
+function makeFakeTx(): TransmissionManager & { sent: AudioFeatureChunk[] } {
+  const sent: AudioFeatureChunk[] = [];
+  return {
+    sent,
+    sendFeatures: (features: unknown) => {
+      sent.push(features as AudioFeatureChunk);
+    },
+  } as unknown as TransmissionManager & { sent: AudioFeatureChunk[] };
 }
 
 // ---------------------------------------------------------------------------
@@ -250,5 +272,43 @@ describe('IAudioPipeline.onFrame()', () => {
     pipeline._emit(makeMockFrame());
 
     expect(received).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-AUDIO-005: start() accepts micHandle and TransmissionManager
+// ---------------------------------------------------------------------------
+
+describe('IAudioPipeline.start() signature', () => {
+  it('TP-CLIENT-AUDIO-005a: accepts sessionId, micHandle, and tx', async () => {
+    const pipeline = new MockAudioPipeline();
+    const tx = makeFakeTx();
+
+    await pipeline.start('session-xyz', {}, tx);
+
+    expect(pipeline.lastStartArgs?.sessionId).toBe('session-xyz');
+    expect(pipeline.lastStartArgs?.tx).toBe(tx);
+  });
+
+  it('TP-CLIENT-AUDIO-005b: tx is optional (undefined when omitted)', async () => {
+    const pipeline = new MockAudioPipeline();
+
+    await pipeline.start('session-xyz', {});
+
+    expect(pipeline.lastStartArgs?.tx).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-AUDIO-006: setVadSensitivity()
+// ---------------------------------------------------------------------------
+
+describe('IAudioPipeline.setVadSensitivity()', () => {
+  it('TP-CLIENT-AUDIO-006a: stores the requested sensitivity level', () => {
+    const pipeline = new MockAudioPipeline();
+
+    pipeline.setVadSensitivity('high');
+
+    expect(pipeline.lastVadSensitivity).toBe('high');
   });
 });

--- a/src/device/DeviceManager.ts
+++ b/src/device/DeviceManager.ts
@@ -10,8 +10,8 @@
 
 import { Audio } from 'expo-av';
 import { Camera as ExpoCamera } from 'expo-camera';
-import type { AudioFeatureChunk, PipelineHealth } from '../common/models';
-import type { IAudioPipeline } from '../pipeline/audio';
+import type { PipelineHealth } from '../common/models';
+import type { IAudioPipeline, RawAudioHandle, SensitivityLevel } from '../pipeline/audio';
 import type { IVideoPipeline, RawMediaHandle } from '../pipeline/video';
 import type { TransmissionManager } from '../transmission/TransmissionManager';
 import type { IDeviceEnumerator } from './DeviceEnumerator';
@@ -87,15 +87,23 @@ export class DeviceManager {
   /**
    * Starts the audio capture pipeline for the given session.
    * Requires `activateMicrophone()` to have been called and granted first.
+   *
+   * The optional `tx` is forwarded to the pipeline, which pushes assembled
+   * AudioFeatureChunks directly to `tx.sendFeatures()`. DeviceManager does
+   * not hold the chunks itself (dependency rule R5).
    */
-  async startAudioPipeline(sessionId: string): Promise<void> {
+  async startAudioPipeline(
+    sessionId: string,
+    micHandle?: RawAudioHandle,
+    tx?: TransmissionManager,
+  ): Promise<void> {
     if (!this.micAvailable) {
       throw new Error('Cannot start audio pipeline: microphone has not been activated.');
     }
     if (!this.audioPipeline) {
       throw new Error('Cannot start audio pipeline: no IAudioPipeline configured.');
     }
-    await this.audioPipeline.start(sessionId);
+    await this.audioPipeline.start(sessionId, micHandle ?? {}, tx);
   }
 
   /**
@@ -140,21 +148,12 @@ export class DeviceManager {
   }
 
   /**
-   * Subscribes to assembled AudioFeatureChunks from the audio pipeline.
-   * Throws if no audio pipeline is configured.
-   * Returns an unsubscribe function.
-   *
-   * NOTE: Requires IAudioPipeline.onChunk() — see audio package note for teammate.
-   * Returns a no-op unsubscribe until that method is added to the interface.
+   * Applies a VAD sensitivity level to the audio pipeline. No-op when no
+   * audio pipeline is configured. Wired by SessionController after
+   * Configuration.load() resolves.
    */
-  onAudioChunk(callback: (chunk: AudioFeatureChunk) => void): () => void {
-    if (!this.audioPipeline) {
-      throw new Error('Cannot subscribe to audio chunks: no IAudioPipeline configured.');
-    }
-    const pipeline = this.audioPipeline as IAudioPipeline & {
-      onChunk?: (cb: (chunk: AudioFeatureChunk) => void) => () => void;
-    };
-    return pipeline.onChunk?.(callback) ?? (() => {});
+  setAudioVadSensitivity(level: SensitivityLevel): void {
+    this.audioPipeline?.setVadSensitivity(level);
   }
 
   /**

--- a/src/pipeline/audio/AudioPipeline.ts
+++ b/src/pipeline/audio/AudioPipeline.ts
@@ -1,4 +1,17 @@
 import type { PipelineHealth } from '../../common/models';
+import type { TransmissionManager } from '../../transmission/TransmissionManager';
+import type { SensitivityLevel } from './VoiceActivityDetector';
+
+/**
+ * Opaque platform-specific microphone handle passed into the audio pipeline.
+ *
+ * Mirrors `RawMediaHandle` on the video side — the interface keeps the field
+ * so the signature matches LLD §3.2.3, even though `ExpoAudioPipeline` does
+ * not use it (expo-av manages the microphone internally via its own Recording
+ * instance). Present for symmetry and for future native modules that do need
+ * a concrete handle.
+ */
+export type RawAudioHandle = Record<string, never>;
 
 /**
  * A single frame of extracted audio features, produced by the audio pipeline
@@ -38,9 +51,18 @@ export interface IAudioPipeline {
    * Resolves once the pipeline is ready to emit frames.
    * Rejects if the device is unavailable.
    *
+   * Assembled `AudioFeatureChunk`s are pushed directly to `tx.sendFeatures()`
+   * as soon as they are produced. Frames are exposed separately via `onFrame`
+   * for local telemetry and testing.
+   *
    * @param sessionId - UUID v4 of the active session.
+   * @param micHandle - Platform-specific microphone handle. Empty object on
+   *   Expo — kept for symmetry with `IVideoPipeline.start`.
+   * @param tx - Optional transmission manager. When provided, completed chunks
+   *   are forwarded to `tx.sendFeatures(chunk)` without an intermediate
+   *   listener. Omit in tests that only need the frame stream.
    */
-  start(sessionId: string): Promise<void>;
+  start(sessionId: string, micHandle: RawAudioHandle, tx?: TransmissionManager): Promise<void>;
 
   /**
    * Suspend frame emission without releasing the microphone.
@@ -73,4 +95,16 @@ export interface IAudioPipeline {
    * Multiple listeners may be registered simultaneously.
    */
   onFrame(callback: (frame: MFCCFrame) => void): () => void;
+
+  /**
+   * Adjust the sensitivity of the internal Voice Activity Detector.
+   *
+   * LLD deviation: §3.2.3 does not expose VAD configuration on the public
+   * pipeline interface. It lives here because `Configuration.load()` is
+   * async — the initial sensitivity has to be applied after pipeline
+   * construction, and routing it through the pipeline is the only way to
+   * reach the VAD without re-introducing an external chunker/VAD ref in
+   * `SessionController` (which §3.2.1 does not permit).
+   */
+  setVadSensitivity(level: SensitivityLevel): void;
 }

--- a/src/pipeline/audio/ExpoAudioPipeline.ts
+++ b/src/pipeline/audio/ExpoAudioPipeline.ts
@@ -1,7 +1,10 @@
 import { Audio } from 'expo-av';
 
 import type { PipelineHealth } from '../../common/models';
-import type { IAudioPipeline, MFCCFrame } from './AudioPipeline';
+import type { TransmissionManager } from '../../transmission/TransmissionManager';
+import type { IAudioPipeline, MFCCFrame, RawAudioHandle } from './AudioPipeline';
+import { AudioChunker } from './AudioChunker';
+import type { SensitivityLevel } from './VoiceActivityDetector';
 
 const FRAME_INTERVAL_MS = 25; // 40 Hz frame rate
 const NUM_MFCC_COEFFICIENTS = 13;
@@ -11,6 +14,10 @@ const NOISE_FLOOR_DBFS = -60; // assumed noise floor for SNR estimation
  * Concrete implementation of IAudioPipeline for Expo (React Native) environments.
  *
  * Uses expo-av for microphone capture and Android/iOS permission management.
+ *
+ * Owns an internal AudioChunker that batches MFCC frames through VAD +
+ * feature extraction; completed chunks are pushed directly to the
+ * TransmissionManager supplied at `start()` time, matching LLD §3.2.3.
  *
  * MFCC extraction is a placeholder based on expo-av's dBFS metering values;
  * it will be replaced with a proper Mel filterbank + DCT computation once raw
@@ -27,12 +34,24 @@ export class ExpoAudioPipeline implements IAudioPipeline {
 
   private recording: Audio.Recording | null = null;
   private frameTimer: ReturnType<typeof setInterval> | null = null;
-  private listeners = new Set<(frame: MFCCFrame) => void>();
+  private frameListeners = new Set<(frame: MFCCFrame) => void>();
 
   /** Most recent dBFS metering value from expo-av status updates. */
   private lastMeteringDbfs = NOISE_FLOOR_DBFS;
 
-  async start(sessionId: string): Promise<void> {
+  private readonly chunker: AudioChunker;
+  private tx: TransmissionManager | null = null;
+  private unsubscribeChunker: (() => void) | null = null;
+
+  constructor(chunker: AudioChunker = new AudioChunker()) {
+    this.chunker = chunker;
+  }
+
+  async start(
+    sessionId: string,
+    _micHandle: RawAudioHandle = {},
+    tx?: TransmissionManager,
+  ): Promise<void> {
     if (this.available || this.paused) return;
 
     await Audio.setAudioModeAsync({
@@ -57,6 +76,12 @@ export class ExpoAudioPipeline implements IAudioPipeline {
     this.sessionStartMs = Date.now();
     this.available = true;
     this.paused = false;
+    this.tx = tx ?? null;
+
+    this.chunker.start(sessionId);
+    this.unsubscribeChunker = this.chunker.onChunk((chunk) => {
+      this.tx?.sendFeatures(chunk);
+    });
 
     this._startFrameTimer();
   }
@@ -80,7 +105,11 @@ export class ExpoAudioPipeline implements IAudioPipeline {
 
   stop(): void {
     this._stopFrameTimer();
-    this.listeners.clear();
+    this.frameListeners.clear();
+    this.unsubscribeChunker?.();
+    this.unsubscribeChunker = null;
+    this.chunker.stop();
+    this.tx = null;
     this.available = false;
     this.paused = false;
     this.sessionId = '';
@@ -104,8 +133,12 @@ export class ExpoAudioPipeline implements IAudioPipeline {
   }
 
   onFrame(callback: (frame: MFCCFrame) => void): () => void {
-    this.listeners.add(callback);
-    return () => this.listeners.delete(callback);
+    this.frameListeners.add(callback);
+    return () => this.frameListeners.delete(callback);
+  }
+
+  setVadSensitivity(level: SensitivityLevel): void {
+    this.chunker.getVoiceActivityDetector().setSensitivity(level);
   }
 
   // ---------------------------------------------------------------------------
@@ -117,7 +150,8 @@ export class ExpoAudioPipeline implements IAudioPipeline {
       const frame = this._extractFrame();
       this.lastUpdatedMs = frame.timestampMs;
       this.currentSnr = Math.max(0, this.lastMeteringDbfs - NOISE_FLOOR_DBFS);
-      this.listeners.forEach((cb) => cb(frame));
+      this.chunker.push(frame);
+      this.frameListeners.forEach((cb) => cb(frame));
     }, FRAME_INTERVAL_MS);
   }
 

--- a/src/pipeline/audio/index.ts
+++ b/src/pipeline/audio/index.ts
@@ -1,4 +1,4 @@
-export type { IAudioPipeline, MFCCFrame } from './AudioPipeline';
+export type { IAudioPipeline, MFCCFrame, RawAudioHandle } from './AudioPipeline';
 export { ExpoAudioPipeline } from './ExpoAudioPipeline';
 export { AudioChunker } from './AudioChunker';
 export { VoiceActivityDetector } from './VoiceActivityDetector';

--- a/src/ui/controller/SessionController.tsx
+++ b/src/ui/controller/SessionController.tsx
@@ -8,7 +8,6 @@ import { DeviceManager, ExpoDeviceEnumerator } from '../../device';
 import { TranscriptStore } from '../../store';
 import { TransmissionManager } from '../../transmission';
 import { Configuration, type IConfigurationManager } from '../../config';
-import { AudioChunker } from '../../pipeline/audio';
 import { buildSessionActions } from './sessionActions';
 
 export type SessionControllerValue = {
@@ -75,21 +74,16 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
 
   const store = useMemo(() => new TranscriptStore(), []);
 
-  const deviceManager = useRef(new DeviceManager(new ExpoDeviceEnumerator(), new ExpoAudioPipeline(), new VideoPipeline()));
-  // TODO(audio-team): This chunker ref is used solely to propagate vadSensitivity from Configuration
-  // on mount. It should be removed once IAudioPipeline exposes getVoiceActivityDetector() directly,
-  // at which point deviceManager.current.getAudioPipeline().getVoiceActivityDetector() is the
-  // correct path. Until then, this standalone instance mirrors the default VAD settings.
-  const audioChunker = useRef(new AudioChunker());
+  const deviceManager = useRef(
+    new DeviceManager(new ExpoDeviceEnumerator(), new ExpoAudioPipeline(), new VideoPipeline()),
+  );
   const config = useRef<IConfigurationManager>(new Configuration());
   const transmissionManager = useRef<TransmissionManager | null>(null);
 
   // Load persisted configuration on mount, then apply settings that gate pipeline behaviour.
   useEffect(() => {
     void config.current.load().then(() => {
-      audioChunker.current
-        .getVoiceActivityDetector()
-        .setSensitivity(config.current.get('vadSensitivity'));
+      deviceManager.current.setAudioVadSensitivity(config.current.get('vadSensitivity'));
     });
   }, []);
 
@@ -142,7 +136,6 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
         const savedMicId = config.current.get('selectedMicId');
         if (savedMicId) deviceManager.current.selectMicrophone(savedMicId);
         await deviceManager.current.activateMicrophone();
-        await deviceManager.current.startAudioPipeline(newSessionId);
       } else if (path === ModalityPath.SIGN) {
         const savedCameraId = config.current.get('selectedCameraId');
         if (savedCameraId) deviceManager.current.selectCamera(savedCameraId);
@@ -159,9 +152,9 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
       );
 
       if (path === ModalityPath.SPEECH) {
-        deviceManager.current.onAudioChunk((chunk) => transmissionManager.current?.sendFeatures(chunk));
+        await deviceManager.current.startAudioPipeline(newSessionId, {}, transmissionManager.current);
       } else if (path === ModalityPath.SIGN) {
-        await deviceManager.current.startVideoPipeline(newSessionId, {}, transmissionManager.current ?? undefined);
+        await deviceManager.current.startVideoPipeline(newSessionId, {}, transmissionManager.current);
       }
 
       // Connect in the background — the 50-frame send buffer holds frames


### PR DESCRIPTION
## What does this PR do?

Reworks the audio pipeline wiring so it matches LLD §3.2.3 and §3.2.1, and fixes the dead `onAudioChunk` path that was sitting on `dev` after #41.

- `IAudioPipeline.start(sessionId)` → `start(sessionId, micHandle, tx?)`, same shape as `IVideoPipeline.start`.
- `ExpoAudioPipeline` now owns its internal `AudioChunker` and forwards completed chunks straight to `tx.sendFeatures` — no listener hop through `DeviceManager` or `SessionController`.
- `DeviceManager.startAudioPipeline(sessionId, micHandle?, tx?)` passes `tx` through; `onAudioChunk` is removed; `setAudioVadSensitivity` is the new entry point for the VAD config.
- `SessionController` drops the standalone `AudioChunker` ref (§3.2.1 lists no chunker on the controller) and applies `vadSensitivity` via `deviceManager.setAudioVadSensitivity` after `config.load()` resolves.

Closes #50.

## LLD deviations

A few things in LLD §3.2.3 are kept as documented deviations — reasoning below, happy to revisit any of them.

1. **`AudioChunker` is push-based.** LLD spec says `nextChunk(micHandle) → RawAudioBuffer`, i.e. pull-based. A pull-based chunker would have to reach into the platform audio API itself, which violates R5 (only the pipeline owns raw media handles). The chunker stays push-based (`push(frame)` + internal `onChunk`) and the pipeline drives it.
2. **`micHandle` parameter is kept but unused on Expo.** `expo-av` manages the microphone internally through its own `Recording` instance, so `ExpoAudioPipeline` doesn't consume the handle. The parameter stays in the interface so the signature matches LLD and lines up with `IVideoPipeline.start(sessionId, cameraHandle, tx)`. Future native modules that do need a real handle can start using it without another interface change.
3. **`setVadSensitivity` on the pipeline interface.** LLD doesn't expose VAD configuration on the pipeline. It lives there because `Configuration.load()` is async — the initial sensitivity has to be applied after pipeline construction, and routing it through the pipeline is the only way to reach the VAD without re-introducing a chunker/VAD ref in `SessionController` (which §3.2.1 does not allow).

## Which package(s) does it touch?

- `sozia.client.pipeline.audio`
- `sozia.client.device`
- `sozia.client.ui`

## How to test

- `npm run check` (typecheck + lint + 246 tests, all green locally)
- New coverage:
  - `TP-CLIENT-AUDIO-005a/b` — `start()` accepts `(sessionId, micHandle, tx)` and `tx` is optional
  - `TP-CLIENT-AUDIO-006a` — `setVadSensitivity` reaches the pipeline
  - `TP-CLIENT-DEVICE-005d` — `DeviceManager` forwards `tx` to the pipeline on `startAudioPipeline`
  - `TP-CLIENT-DEVICE-010a/b` — `setAudioVadSensitivity` delegates and is a no-op when no pipeline is configured

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests
- [x] No sozia.common schema changes
- [x] Tested locally (npm run check clean)