### PR TITLE
chore(audio-pipeline,device): migrate expo-av → expo-audio

### DIFF
--- a/__tests__/device/DeviceManager.test.ts
+++ b/__tests__/device/DeviceManager.test.ts
@@ -8,7 +8,7 @@
  * Uses mock IDeviceEnumerator and mock IAudioPipeline to verify DeviceManager
  * behaviour in isolation. ExpoDeviceEnumerator is excluded (requires platform APIs).
  *
- * Test plan reference: TP-CLIENT-DEVICE-001 through TP-CLIENT-DEVICE-008
+ * Test plan reference: TP-CLIENT-DEVICE-001 through TP-CLIENT-DEVICE-010
  */
 
 jest.mock('expo-audio', () => ({
@@ -413,40 +413,6 @@ describe('DeviceManager.startVideoPipeline()', () => {
 });
 
 // ---------------------------------------------------------------------------
-// TP-CLIENT-DEVICE-009: getVideoHealth()
-// ---------------------------------------------------------------------------
-
-describe('DeviceManager.getVideoHealth()', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockRequestCameraPermissions.mockResolvedValue({ granted: true, status: 'granted' });
-  });
-
-  it('TP-CLIENT-DEVICE-009a: returns a zeroed health object when no video pipeline is configured', () => {
-    const manager = new DeviceManager(new MockDeviceEnumerator());
-
-    const health = manager.getVideoHealth();
-
-    expect(health.pipeline).toBe('video');
-    expect(health.available).toBe(false);
-    expect(health.sessionId).toBe('');
-  });
-
-  it('TP-CLIENT-DEVICE-009b: delegates to videoPipeline.getHealth() when configured', async () => {
-    const pipeline = new MockVideoPipeline();
-    const manager = new DeviceManager(new MockDeviceEnumerator(), null, pipeline);
-    await manager.activateCamera();
-    await manager.startVideoPipeline('sess-health');
-
-    const health = manager.getVideoHealth();
-
-    expect(health.pipeline).toBe('video');
-    expect(health.sessionId).toBe('sess-health');
-    expect(health.available).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // TP-CLIENT-DEVICE-007: stopAllPipelines()
 // ---------------------------------------------------------------------------
 
@@ -485,6 +451,60 @@ describe('DeviceManager.stopAllPipelines()', () => {
 });
 
 // ---------------------------------------------------------------------------
+// TP-CLIENT-DEVICE-008: DeviceHandle shape
+// ---------------------------------------------------------------------------
+
+describe('DeviceHandle', () => {
+  it('TP-CLIENT-DEVICE-008a: has deviceId, label, kind, and isDefault fields', () => {
+    const device = makeAudioDevice();
+
+    expect(typeof device.deviceId).toBe('string');
+    expect(typeof device.label).toBe('string');
+    expect(device.kind === 'audioinput' || device.kind === 'videoinput').toBe(true);
+    expect(typeof device.isDefault).toBe('boolean');
+  });
+
+  it('TP-CLIENT-DEVICE-008b: kind discriminates audioinput from videoinput', () => {
+    expect(makeAudioDevice().kind).toBe('audioinput');
+    expect(makeVideoDevice().kind).toBe('videoinput');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-DEVICE-009: getVideoHealth()
+// ---------------------------------------------------------------------------
+
+describe('DeviceManager.getVideoHealth()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequestCameraPermissions.mockResolvedValue({ granted: true, status: 'granted' });
+  });
+
+  it('TP-CLIENT-DEVICE-009a: returns a zeroed health object when no video pipeline is configured', () => {
+    const manager = new DeviceManager(new MockDeviceEnumerator());
+
+    const health = manager.getVideoHealth();
+
+    expect(health.pipeline).toBe('video');
+    expect(health.available).toBe(false);
+    expect(health.sessionId).toBe('');
+  });
+
+  it('TP-CLIENT-DEVICE-009b: delegates to videoPipeline.getHealth() when configured', async () => {
+    const pipeline = new MockVideoPipeline();
+    const manager = new DeviceManager(new MockDeviceEnumerator(), null, pipeline);
+    await manager.activateCamera();
+    await manager.startVideoPipeline('sess-health');
+
+    const health = manager.getVideoHealth();
+
+    expect(health.pipeline).toBe('video');
+    expect(health.sessionId).toBe('sess-health');
+    expect(health.available).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // TP-CLIENT-DEVICE-010: setAudioVadSensitivity()
 // ---------------------------------------------------------------------------
 
@@ -502,25 +522,5 @@ describe('DeviceManager.setAudioVadSensitivity()', () => {
     const manager = new DeviceManager(new MockDeviceEnumerator());
 
     expect(() => manager.setAudioVadSensitivity('low')).not.toThrow();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// TP-CLIENT-DEVICE-008: DeviceHandle shape
-// ---------------------------------------------------------------------------
-
-describe('DeviceHandle', () => {
-  it('TP-CLIENT-DEVICE-008a: has deviceId, label, kind, and isDefault fields', () => {
-    const device = makeAudioDevice();
-
-    expect(typeof device.deviceId).toBe('string');
-    expect(typeof device.label).toBe('string');
-    expect(device.kind === 'audioinput' || device.kind === 'videoinput').toBe(true);
-    expect(typeof device.isDefault).toBe('boolean');
-  });
-
-  it('TP-CLIENT-DEVICE-008b: kind discriminates audioinput from videoinput', () => {
-    expect(makeAudioDevice().kind).toBe('audioinput');
-    expect(makeVideoDevice().kind).toBe('videoinput');
   });
 });

--- a/__tests__/device/DeviceManager.test.ts
+++ b/__tests__/device/DeviceManager.test.ts
@@ -11,10 +11,8 @@
  * Test plan reference: TP-CLIENT-DEVICE-001 through TP-CLIENT-DEVICE-008
  */
 
-jest.mock('expo-av', () => ({
-  Audio: {
-    requestPermissionsAsync: jest.fn(),
-  },
+jest.mock('expo-audio', () => ({
+  requestRecordingPermissionsAsync: jest.fn(),
 }));
 
 jest.mock('expo-camera', () => ({
@@ -23,7 +21,7 @@ jest.mock('expo-camera', () => ({
   },
 }));
 
-import { Audio } from 'expo-av';
+import { requestRecordingPermissionsAsync } from 'expo-audio';
 import { Camera as ExpoCamera } from 'expo-camera';
 import { DeviceManager } from '../../src/device/DeviceManager';
 import type { IDeviceEnumerator } from '../../src/device/DeviceEnumerator';
@@ -38,7 +36,7 @@ import type { IVideoPipeline, RawMediaHandle } from '../../src/pipeline/video';
 import type { PipelineHealth } from '../../src/common/models';
 import type { TransmissionManager } from '../../src/transmission/TransmissionManager';
 
-const mockRequestPermissions = Audio.requestPermissionsAsync as jest.Mock;
+const mockRequestPermissions = requestRecordingPermissionsAsync as jest.Mock;
 const mockRequestCameraPermissions = ExpoCamera.requestCameraPermissionsAsync as jest.Mock;
 
 // ---------------------------------------------------------------------------

--- a/__tests__/pipeline/audio/AudioPipeline.test.ts
+++ b/__tests__/pipeline/audio/AudioPipeline.test.ts
@@ -9,7 +9,7 @@
  * correct and complete. They serve as the acceptance baseline for any
  * concrete implementation (e.g. ExpoAudioPipeline) that ships later.
  *
- * Test plan reference: TP-CLIENT-AUDIO-001 through TP-CLIENT-AUDIO-008
+ * Test plan reference: TP-CLIENT-AUDIO-001 through TP-CLIENT-AUDIO-007
  */
 
 import type { IAudioPipeline, MFCCFrame, RawAudioHandle, SensitivityLevel } from '../../../src/pipeline/audio';
@@ -310,5 +310,23 @@ describe('IAudioPipeline.setVadSensitivity()', () => {
     pipeline.setVadSensitivity('high');
 
     expect(pipeline.lastVadSensitivity).toBe('high');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-AUDIO-007: RecordingPresets shape guard
+// ---------------------------------------------------------------------------
+
+describe('RecordingPresets.HIGH_QUALITY shape', () => {
+  it('TP-CLIENT-AUDIO-007a: has the top-level keys flattenRecordingOptions depends on', () => {
+    // Read the declaration source to verify the RecordingOptions shape hasn't changed.
+    // Direct require() of expo-audio fails under Jest (ESM), so we inspect the .d.ts.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fs = jest.requireActual<any>('fs');
+    const typeDef = fs.readFileSync('node_modules/expo-audio/build/RecordingConstants.d.ts', 'utf8') as string;
+
+    for (const key of ['extension', 'sampleRate', 'numberOfChannels', 'bitRate', 'ios', 'android', 'web']) {
+      expect(typeDef).toContain(key);
+    }
   });
 });

--- a/app.json
+++ b/app.json
@@ -13,7 +13,8 @@
           "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone.",
           "recordAudioAndroid": false
         }
-      ]
+      ],
+      "expo-audio"
     ],
     "ios": {
       "supportsTablet": true

--- a/app.json
+++ b/app.json
@@ -14,7 +14,12 @@
           "recordAudioAndroid": false
         }
       ],
-      "expo-audio"
+      [
+        "expo-audio",
+        {
+          "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone."
+        }
+      ]
     ],
     "ios": {
       "supportsTablet": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "babel-preset-expo": "~54.0.10",
         "expo": "~54.0.33",
-        "expo-av": "^16.0.8",
+        "expo-audio": "~1.1.1",
         "expo-camera": "~17.0.10",
         "expo-status-bar": "~3.0.9",
         "lucide-react-native": "^0.577.0",
@@ -5688,21 +5688,16 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-av": {
-      "version": "16.0.8",
-      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-16.0.8.tgz",
-      "integrity": "sha512-cmVPftGR/ca7XBgs7R6ky36lF3OC0/MM/lpgX/yXqfv0jASTsh7AYX9JxHCwFmF+Z6JEB1vne9FDx4GiLcGreQ==",
+    "node_modules/expo-audio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-1.1.1.tgz",
+      "integrity": "sha512-CPCpJ+0AEHdzWROc0f00Zh6e+irLSl2ALos/LPvxEeIcJw1APfBa4DuHPkL4CQCWsVe7EnUjFpdwpqsEUWcP0g==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
+        "expo-asset": "*",
         "react": "*",
-        "react-native": "*",
-        "react-native-web": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-web": {
-          "optional": true
-        }
+        "react-native": "*"
       }
     },
     "node_modules/expo-camera": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1851,9 +1851,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/fingerprint/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2073,9 +2073,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/metro-config/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2686,9 +2686,9 @@
       "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3102,9 +3102,9 @@
       "license": "MIT"
     },
     "node_modules/@react-native/codegen/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3714,9 +3714,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4248,9 +4248,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6064,9 +6064,9 @@
       "license": "MIT"
     },
     "node_modules/expo/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6117,9 +6117,9 @@
       }
     },
     "node_modules/expo/node_modules/picomatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
-      "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.2.tgz",
+      "integrity": "sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6512,9 +6512,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7237,9 +7237,9 @@
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7601,9 +7601,9 @@
       "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8997,9 +8997,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -9458,9 +9458,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -10450,9 +10450,9 @@
       "license": "MIT"
     },
     "node_modules/react-native/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -10775,9 +10775,9 @@
       "license": "MIT"
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11434,9 +11434,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11537,9 +11537,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -12156,9 +12156,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "babel-preset-expo": "~54.0.10",
     "expo": "~54.0.33",
-    "expo-av": "^16.0.8",
+    "expo-audio": "~1.1.1",
     "expo-camera": "~17.0.10",
     "expo-status-bar": "~3.0.9",
     "lucide-react-native": "^0.577.0",

--- a/src/device/DeviceEnumerator.ts
+++ b/src/device/DeviceEnumerator.ts
@@ -18,7 +18,7 @@ export interface IDeviceEnumerator {
    * Registers a callback that fires whenever the set of available devices
    * changes (e.g. a headset is plugged in or removed).
    * On native platforms this is a no-op — device changes are rare and not
-   * exposed by expo-av.
+   * exposed by expo-audio.
    *
    * Returns a cleanup function that removes the listener.
    */
@@ -29,7 +29,7 @@ export interface IDeviceEnumerator {
  * Concrete enumerator that works on both web and React Native (Expo) targets.
  *
  * - **Web**: delegates to `navigator.mediaDevices.enumerateDevices()`.
- * - **Native (iOS / Android)**: expo-av does not expose device enumeration;
+ * - **Native (iOS / Android)**: expo-audio does not expose device enumeration;
  *   returns two synthetic default entries so the rest of the system can
  *   operate without branching.
  */

--- a/src/device/DeviceManager.ts
+++ b/src/device/DeviceManager.ts
@@ -8,7 +8,7 @@
  * permissions and delegates capture to the pipeline instances it holds.
  */
 
-import { Audio } from 'expo-av';
+import { requestRecordingPermissionsAsync } from 'expo-audio';
 import { Camera as ExpoCamera } from 'expo-camera';
 import type { PipelineHealth } from '../common/models';
 import type { IAudioPipeline, RawAudioHandle, SensitivityLevel } from '../pipeline/audio';
@@ -58,7 +58,7 @@ export class DeviceManager {
    * Throws with an actionable message if permission is denied.
    */
   async activateMicrophone(): Promise<void> {
-    const { granted } = await Audio.requestPermissionsAsync();
+    const { granted } = await requestRecordingPermissionsAsync();
     if (!granted) {
       this.micAvailable = false;
       throw new Error(

--- a/src/pipeline/audio/AudioPipeline.ts
+++ b/src/pipeline/audio/AudioPipeline.ts
@@ -7,7 +7,7 @@ import type { SensitivityLevel } from './VoiceActivityDetector';
  *
  * Mirrors `RawMediaHandle` on the video side — the interface keeps the field
  * so the signature matches LLD §3.2.3, even though `ExpoAudioPipeline` does
- * not use it (expo-av manages the microphone internally via its own Recording
+ * not use it (expo-audio manages the microphone internally via its own AudioRecorder
  * instance). Present for symmetry and for future native modules that do need
  * a concrete handle.
  */

--- a/src/pipeline/audio/ExpoAudioPipeline.ts
+++ b/src/pipeline/audio/ExpoAudioPipeline.ts
@@ -1,4 +1,11 @@
-import { Audio } from 'expo-av';
+import {
+  AudioModule,
+  RecordingPresets,
+  setAudioModeAsync,
+  type AudioRecorder,
+  type RecordingOptions,
+} from 'expo-audio';
+import { Platform } from 'react-native';
 
 import type { PipelineHealth } from '../../common/models';
 import type { TransmissionManager } from '../../transmission/TransmissionManager';
@@ -11,18 +18,38 @@ const NUM_MFCC_COEFFICIENTS = 13;
 const NOISE_FLOOR_DBFS = -60; // assumed noise floor for SNR estimation
 
 /**
+ * Flattens a cross-platform `RecordingOptions` object into the platform-specific
+ * shape the native `AudioRecorder` constructor expects.
+ *
+ * Mirrors `expo-audio`'s internal `createRecordingOptions` helper — the hook
+ * (`useAudioRecorder`) runs this before calling `new AudioRecorder(...)`. We
+ * can't use the hook from a plain class, so we replicate the flattening
+ * inline rather than reach into `expo-audio/utils/options` (private path).
+ */
+function flattenRecordingOptions(options: RecordingOptions): Record<string, unknown> {
+  const common = {
+    extension: options.extension,
+    sampleRate: options.sampleRate,
+    numberOfChannels: options.numberOfChannels,
+    bitRate: options.bitRate,
+    isMeteringEnabled: options.isMeteringEnabled ?? false,
+  };
+  if (Platform.OS === 'ios') return { ...common, ...options.ios };
+  if (Platform.OS === 'android') return { ...common, ...options.android };
+  return { ...common, ...options.web };
+}
+
+/**
  * Concrete implementation of IAudioPipeline for Expo (React Native) environments.
  *
- * Uses expo-av for microphone capture and Android/iOS permission management.
+ * Uses `expo-audio` for microphone capture. Owns an internal AudioChunker that
+ * batches MFCC frames through VAD + feature extraction; completed chunks are
+ * pushed directly to the TransmissionManager supplied at `start()` time,
+ * matching LLD §3.2.3.
  *
- * Owns an internal AudioChunker that batches MFCC frames through VAD +
- * feature extraction; completed chunks are pushed directly to the
- * TransmissionManager supplied at `start()` time, matching LLD §3.2.3.
- *
- * MFCC extraction is a placeholder based on expo-av's dBFS metering values;
+ * MFCC extraction is a placeholder based on expo-audio's dBFS metering values;
  * it will be replaced with a proper Mel filterbank + DCT computation once raw
- * PCM sample buffers are accessible (expo-av does not expose PCM in managed
- * workflow). See `_placeholderMfcc()` for details.
+ * PCM sample buffers are accessible. See `_placeholderMfcc()` for details.
  */
 export class ExpoAudioPipeline implements IAudioPipeline {
   private sessionId = '';
@@ -32,11 +59,11 @@ export class ExpoAudioPipeline implements IAudioPipeline {
   private lastUpdatedMs = 0;
   private currentSnr: number | null = null;
 
-  private recording: Audio.Recording | null = null;
+  private recorder: AudioRecorder | null = null;
   private frameTimer: ReturnType<typeof setInterval> | null = null;
   private frameListeners = new Set<(frame: MFCCFrame) => void>();
 
-  /** Most recent dBFS metering value from expo-av status updates. */
+  /** Most recent dBFS metering value polled from the recorder. */
   private lastMeteringDbfs = NOISE_FLOOR_DBFS;
 
   private readonly chunker: AudioChunker;
@@ -54,24 +81,20 @@ export class ExpoAudioPipeline implements IAudioPipeline {
   ): Promise<void> {
     if (this.available || this.paused) return;
 
-    await Audio.setAudioModeAsync({
-      allowsRecordingIOS: true,
-      playsInSilentModeIOS: true,
+    await setAudioModeAsync({
+      allowsRecording: true,
+      playsInSilentMode: true,
     });
 
-    const { recording } = await Audio.Recording.createAsync({
-      ...Audio.RecordingOptionsPresets.HIGH_QUALITY,
+    const options = flattenRecordingOptions({
+      ...RecordingPresets.HIGH_QUALITY,
       isMeteringEnabled: true,
     });
+    const recorder = new AudioModule.AudioRecorder(options);
+    await recorder.prepareToRecordAsync();
+    recorder.record();
 
-    recording.setOnRecordingStatusUpdate((status) => {
-      if (status.metering != null) {
-        this.lastMeteringDbfs = status.metering;
-      }
-    });
-    recording.setProgressUpdateInterval(FRAME_INTERVAL_MS);
-
-    this.recording = recording;
+    this.recorder = recorder;
     this.sessionId = sessionId;
     this.sessionStartMs = Date.now();
     this.available = true;
@@ -91,15 +114,15 @@ export class ExpoAudioPipeline implements IAudioPipeline {
     this.paused = true;
     this.available = false;
     this._stopFrameTimer();
-    this.recording?.pauseAsync().catch(() => {});
+    this.recorder?.pause();
   }
 
   resume(): void {
     if (!this.paused) return;
     this.paused = false;
     this.available = true;
-    // expo-av: startAsync() resumes a paused recording
-    this.recording?.startAsync().catch(() => {});
+    // expo-audio: record() also resumes a paused recorder.
+    this.recorder?.record();
     this._startFrameTimer();
   }
 
@@ -115,9 +138,9 @@ export class ExpoAudioPipeline implements IAudioPipeline {
     this.sessionId = '';
     this.currentSnr = null;
 
-    const rec = this.recording;
-    this.recording = null;
-    rec?.stopAndUnloadAsync().catch(() => {});
+    const rec = this.recorder;
+    this.recorder = null;
+    rec?.stop().catch(() => {});
   }
 
   getHealth(): PipelineHealth {
@@ -147,6 +170,12 @@ export class ExpoAudioPipeline implements IAudioPipeline {
 
   private _startFrameTimer(): void {
     this.frameTimer = setInterval(() => {
+      if (this.recorder) {
+        const status = this.recorder.getStatus();
+        if (typeof status.metering === 'number') {
+          this.lastMeteringDbfs = status.metering;
+        }
+      }
       const frame = this._extractFrame();
       this.lastUpdatedMs = frame.timestampMs;
       this.currentSnr = Math.max(0, this.lastMeteringDbfs - NOISE_FLOOR_DBFS);
@@ -178,9 +207,9 @@ export class ExpoAudioPipeline implements IAudioPipeline {
    * via a deterministic cosine transform of a flat log-Mel spectrum.
    *
    * PLACEHOLDER — must be replaced with a proper Mel filterbank + DCT pipeline
-   * once expo-av (or an alternative module) exposes raw PCM sample buffers.
-   * The output satisfies the MFCCFrame contract (13 finite floats) and enables
-   * full pipeline wiring and device-level testing without PCM access.
+   * once raw PCM sample buffers are accessible. The output satisfies the
+   * MFCCFrame contract (13 finite floats) and enables full pipeline wiring
+   * and device-level testing without PCM access.
    */
   private _placeholderMfcc(linearEnergy: number): number[] {
     const logEnergy = Math.log(linearEnergy + 1e-10);

--- a/src/pipeline/audio/ExpoAudioPipeline.ts
+++ b/src/pipeline/audio/ExpoAudioPipeline.ts
@@ -17,15 +17,8 @@ const FRAME_INTERVAL_MS = 25; // 40 Hz frame rate
 const NUM_MFCC_COEFFICIENTS = 13;
 const NOISE_FLOOR_DBFS = -60; // assumed noise floor for SNR estimation
 
-/**
- * Flattens a cross-platform `RecordingOptions` object into the platform-specific
- * shape the native `AudioRecorder` constructor expects.
- *
- * Mirrors `expo-audio`'s internal `createRecordingOptions` helper — the hook
- * (`useAudioRecorder`) runs this before calling `new AudioRecorder(...)`. We
- * can't use the hook from a plain class, so we replicate the flattening
- * inline rather than reach into `expo-audio/utils/options` (private path).
- */
+// Mirrors expo-audio@1.1.x internal `createRecordingOptions`. Revisit on upgrade.
+// See TP-CLIENT-AUDIO-007 for shape assertion.
 function flattenRecordingOptions(options: RecordingOptions): Record<string, unknown> {
   const common = {
     extension: options.extension,
@@ -140,7 +133,12 @@ export class ExpoAudioPipeline implements IAudioPipeline {
 
     const rec = this.recorder;
     this.recorder = null;
-    rec?.stop().catch(() => {});
+    rec
+      ?.stop()
+      .then(() => setAudioModeAsync({ allowsRecording: false }))
+      .catch((err: unknown) => {
+        console.warn('[ExpoAudioPipeline] stop cleanup failed:', err);
+      });
   }
 
   getHealth(): PipelineHealth {


### PR DESCRIPTION
## What does this PR do?

Removes the deprecated `expo-av` dependency and switches the audio stack to `expo-audio`. Fixes the `[expo-av]: Expo AV has been deprecated` warning that was showing up during Metro bundling. Closes #53.

`ExpoAudioPipeline` now builds the recorder directly via `AudioModule.AudioRecorder` and polls metering through `recorder.getStatus()` on each frame tick. `expo-audio` exposes its option-flattening helper as a private path, so the platform-specific merge is inlined — small and self-contained, mirrors what `useAudioRecorder` does internally.

`DeviceManager.activateMicrophone` swaps `Audio.requestPermissionsAsync()` for `requestRecordingPermissionsAsync()` from `expo-audio`. Two-line permission change; behavior is identical.

## Which package(s) does it touch?

- \`sozia.client.pipeline.audio\` (owned) — ExpoAudioPipeline rewrite
- \`sozia.client.device\` (teammate) — 2-line permission API swap, no interface changes
- config: \`package.json\`, \`app.json\` (plugins list)
- tests: DeviceManager + AudioPipeline mocks

## How to test

- [x] \`npm run check\` — 18 suites, 246 tests, typecheck + lint clean
- [x] \`npx expo start --web\` — bundle completes with no \`expo-av\` / deprecated mentions
- [x] \`node_modules/expo-av\` fully gone after install

## Checklist
- [x] Follows commit convention (\`<type>(<scope>): <description>\`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally