### PR TITLE
feat(common): add shared interface contracts and align feature extrators

### DIFF
--- a/src/common/interfaces/index.ts
+++ b/src/common/interfaces/index.ts
@@ -1,0 +1,112 @@
+import type {
+  ModelConfig,
+  ModalityResult,
+  PipelineHealth,
+  TranscriptSegment,
+} from '../models';
+
+/**
+ * Abstract contract for every AI inference component.
+ *
+ * Client code does not implement this today, but the shared definition keeps the
+ * wire contract aligned with the server-side LLD and future mirrored Python types.
+ *
+ * @typeParam TFeatures - Engine input payload, such as an audio feature matrix or gloss text.
+ */
+export interface InferenceEngine<TFeatures = unknown> {
+  /**
+   * Load model weights and prepare the engine for inference.
+   *
+   * @param config - Model selection and runtime configuration.
+   * @returns A promise that resolves when the model is ready to serve predictions.
+   */
+  loadModel(config: ModelConfig): Promise<void>;
+
+  /**
+   * Run inference on preprocessed features.
+   *
+   * @param features - Preprocessed, anonymized model input.
+   * @param timeoutMs - Maximum wall-clock time allowed for the prediction.
+   * @returns The engine output used by fusion/post-processing.
+   */
+  predict(features: TFeatures, timeoutMs: number): Promise<ModalityResult>;
+
+  /**
+   * Release model resources such as memory or GPU allocations.
+   *
+   * @returns A promise that resolves once cleanup is complete.
+   */
+  unloadModel(): Promise<void>;
+
+  /**
+   * Indicates whether a model is currently loaded and ready.
+   *
+   * @returns `true` when predictions can be served.
+   */
+  isLoaded(): boolean;
+
+  /**
+   * Returns the identifier of the currently loaded model.
+   *
+   * @returns A stable model id, or an empty string if nothing is loaded.
+   */
+  getModelId(): string;
+}
+
+/**
+ * Abstract contract for server-side fusion strategies.
+ *
+ * Different paths can implement different policies while sharing the same
+ * inputs and outputs.
+ */
+export interface FusionStrategy {
+  /**
+   * Merge one or more modality outputs into transcript segments.
+   *
+   * @param results - Inference outputs that are candidates for fusion.
+   * @param health - Latest pipeline health reports used for degraded-mode decisions.
+   * @returns One or more transcript segments, typically a partial followed by a final.
+   */
+  fuse(results: ModalityResult[], health: PipelineHealth[]): TranscriptSegment[];
+
+  /**
+   * Decide whether a modality result should be excluded from fusion.
+   *
+   * @param result - Candidate inference result.
+   * @returns `true` when the result should be suppressed.
+   */
+  shouldSuppress(result: ModalityResult): boolean;
+
+  /**
+   * Return the minimum confidence threshold used by this strategy.
+   *
+   * @returns A numeric threshold in the range `[0.0, 1.0]`.
+   */
+  getConfidenceThreshold(): number;
+}
+
+/**
+ * Shared contract for client-side feature extraction.
+ *
+ * Raw input types remain package-local, but every extractor exposes the same
+ * readiness and extraction surface.
+ *
+ * @typeParam TRawInput - Opaque media/input type owned by the pipeline package.
+ * @typeParam TFeatureOutput - Extracted feature payload or DTO.
+ */
+export interface FeatureExtractor<TRawInput = unknown, TFeatureOutput = unknown> {
+  /**
+   * Transform raw input into a feature payload suitable for downstream processing.
+   *
+   * @param rawInput - Package-local raw input.
+   * @returns The extracted payload, or `null` when extraction fails.
+   */
+  extract(rawInput: TRawInput): TFeatureOutput | null;
+
+  /**
+   * Report whether the extractor is initialized and ready.
+   *
+   * @returns `true` when `extract()` can be called safely.
+   */
+  isReady(): boolean;
+}

--- a/src/common/models/index.ts
+++ b/src/common/models/index.ts
@@ -79,6 +79,18 @@ export interface AudioFeatureChunk {
   chunkDurationMs: number;
 }
 
+/** Configuration payload for loading a concrete model implementation (LLD UML DTO). */
+export interface ModelConfig {
+  /** Stable identifier such as `whisper-small-tr` or `gemma-9b-gloss-tr`. */
+  modelId: string;
+  /** Filesystem or remote path to the model weights/artifact. */
+  weightsPath: string;
+  /** Preferred execution device for the engine. */
+  device: 'cpu' | 'cuda';
+  /** Optional engine-specific settings such as quantization or beam width. */
+  parameters?: Record<string, unknown>;
+}
+
 /** Output of a single inference engine (LLD §3.1.2). Server-side, consumed by FusionOrchestrator. */
 export interface ModalityResult {
   modalityType: ModalityType;

--- a/src/common/models/index.ts
+++ b/src/common/models/index.ts
@@ -82,13 +82,13 @@ export interface AudioFeatureChunk {
 /** Configuration payload for loading a concrete model implementation (LLD UML DTO). */
 export interface ModelConfig {
   /** Stable identifier such as `whisper-small-tr` or `gemma-9b-gloss-tr`. */
-  modelId: string;
+  model_id: string;
   /** Filesystem or remote path to the model weights/artifact. */
-  weightsPath: string;
-  /** Preferred execution device for the engine. */
-  device: 'cpu' | 'cuda';
-  /** Optional engine-specific settings such as quantization or beam width. */
-  parameters?: Record<string, unknown>;
+  weights_path: string;
+  /** Compute device. Server validation constrains this to values such as `cpu` or `cuda`. */
+  device: string;
+  /** Engine-specific parameters mirrored from the server-side dataclass. */
+  params: Record<string, unknown>;
 }
 
 /** Output of a single inference engine (LLD §3.1.2). Server-side, consumed by FusionOrchestrator. */

--- a/src/pipeline/audio/AudioFeatureExtractor.ts
+++ b/src/pipeline/audio/AudioFeatureExtractor.ts
@@ -1,15 +1,6 @@
+import type { FeatureExtractor } from '../../common/interfaces';
 import type { AudioFeatureChunk } from '../../common/models';
 import type { MFCCFrame } from './AudioPipeline';
-
-/**
- * Contract for any feature extraction stage in the pipeline.
- * Each implementation converts raw input into a typed feature chunk
- * suitable for transmission.
- */
-export interface FeatureExtractor<TInput, TOutput> {
-  extract(rawInput: TInput): TOutput | null;
-  isReady(): boolean;
-}
 
 /**
  * Converts a batch of MFCCFrames into an AudioFeatureChunk ready for

--- a/src/pipeline/audio/index.ts
+++ b/src/pipeline/audio/index.ts
@@ -4,4 +4,4 @@ export { AudioChunker } from './AudioChunker';
 export { VoiceActivityDetector } from './VoiceActivityDetector';
 export type { SensitivityLevel } from './VoiceActivityDetector';
 export { AudioFeatureExtractor } from './AudioFeatureExtractor';
-export type { FeatureExtractor } from './AudioFeatureExtractor';
+export type { FeatureExtractor } from '../../common/interfaces';

--- a/src/pipeline/video/LandmarkExtractor.ts
+++ b/src/pipeline/video/LandmarkExtractor.ts
@@ -5,6 +5,7 @@
  * remain local to the video pipeline package.
  */
 
+import type { FeatureExtractor } from '../../common/interfaces';
 import type { LandmarkFrame } from '../../common/models';
 
 /** Opaque raw frame payload captured from the camera runtime. */
@@ -39,7 +40,7 @@ export class NullLandmarkBackend implements LandmarkExtractionBackend {
 /**
  * Wrapper around a concrete landmark backend.
  */
-export class LandmarkExtractor {
+export class LandmarkExtractor implements FeatureExtractor<RawVideoFrame, LandmarkFrame> {
   private readonly backend: LandmarkExtractionBackend;
 
   constructor(backend: LandmarkExtractionBackend = new NullLandmarkBackend()) {


### PR DESCRIPTION
## What does this PR do?

- Adds the sozia.common.interfaces package and aligns the shared-layer split with the LLD/UML. Shared behavioral contracts now live under src/common/interfaces, while shared enums/DTOs stay under src/common/models.

- Defines FeatureExtractor, InferenceEngine, and FusionStrategy in sozia.common.interfaces. ModelConfig is placed in sozia.common.models because it is shown as a DTO in the UML, not as a behavioral contract.

- Removes the duplicated local FeatureExtractor definition from the audio pipeline and makes both extractor implementations use the shared contract. AudioFeatureExtractor now imports the common FeatureExtractor, and LandmarkExtractor explicitly implements it.

## Which package(s) does it touch?

- sozia.common.interfaces — new shared interface contracts
- sozia.common.models — adds ModelConfig DTO to match UML/LLD split
- sozia.client.pipeline.audio — removes local FeatureExtractor duplication, re-exports shared contract
- sozia.client.pipeline.video — aligns LandmarkExtractor with shared FeatureExtractor


## How to test

-npm run check

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [ ] Added/updated tests (if applicable)
- [ ] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally