### PR TITLE
feat(ui): request camera and microphone access from the permissions screen

### DIFF
--- a/src/ui/i18n/locales/en.json
+++ b/src/ui/i18n/locales/en.json
@@ -32,6 +32,8 @@
       "privacy": "Your privacy matters. ",
       "privacyDesc": "All processing happens on your device. No video or audio is stored or transmitted.",
       "allowAccess": "Allow Access",
+      "requestingAccess": "Requesting access...",
+      "permissionError": "Camera and microphone access are required to continue.",
       "skip": "Skip for now",
       "back": "Back"
     },

--- a/src/ui/i18n/locales/tr.json
+++ b/src/ui/i18n/locales/tr.json
@@ -32,6 +32,8 @@
       "privacy": "Gizliliğiniz önemlidir. ",
       "privacyDesc": "Tüm işlemler cihazınızda gerçekleşir. Hiçbir video veya ses saklanmaz veya iletilmez.",
       "allowAccess": "Erişim İzni Ver",
+      "requestingAccess": "Erişim isteniyor...",
+      "permissionError": "Devam etmek için kamera ve mikrofon erişimi gereklidir.",
       "skip": "Şimdilik atla",
       "back": "Geri"
     },

--- a/src/ui/screens/PermissionsScreen.tsx
+++ b/src/ui/screens/PermissionsScreen.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import { requestRecordingPermissionsAsync } from 'expo-audio';
+import { Camera as ExpoCamera } from 'expo-camera';
+import React, { useState } from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Camera, MessageCircle, Mic } from 'lucide-react-native';
@@ -6,6 +8,31 @@ import { useLanguage } from '../context/LanguageContext';
 
 export function PermissionsScreen({ onNext, onBack }: { onNext: () => void; onBack: () => void }) {
   const { t } = useLanguage();
+  const [isRequesting, setIsRequesting] = useState(false);
+  const [permissionError, setPermissionError] = useState<string | null>(null);
+
+  const handleAllowAccess = async () => {
+    if (isRequesting) return;
+
+    setIsRequesting(true);
+    setPermissionError(null);
+
+    try {
+      const cameraPermission = await ExpoCamera.requestCameraPermissionsAsync();
+      const microphonePermission = await requestRecordingPermissionsAsync();
+
+      if (!cameraPermission.granted || !microphonePermission.granted) {
+        setPermissionError(t('permissions.permissionError'));
+        return;
+      }
+
+      onNext();
+    } catch {
+      setPermissionError(t('permissions.permissionError'));
+    } finally {
+      setIsRequesting(false);
+    }
+  };
 
   return (
     <SafeAreaView className="flex-1 w-full self-stretch bg-gradient-to-br from-[#2ECC71]/5 via-white dark:via-gray-900 to-[#2ECC71]/5">
@@ -57,12 +84,25 @@ export function PermissionsScreen({ onNext, onBack }: { onNext: () => void; onBa
               </Text>
             </View>
 
+            {permissionError && (
+              <View className="mb-4 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-950/40">
+                <Text className="text-center text-sm text-red-700 dark:text-red-300">
+                  {permissionError}
+                </Text>
+              </View>
+            )}
+
             <TouchableOpacity
-              className="mb-3 h-14 w-full items-center justify-center rounded-2xl bg-[#2ECC71] shadow-xl"
-              onPress={onNext}
+              className={`mb-3 h-14 w-full items-center justify-center rounded-2xl bg-[#2ECC71] shadow-xl ${isRequesting ? 'opacity-70' : ''}`}
+              onPress={() => {
+                void handleAllowAccess();
+              }}
               activeOpacity={0.9}
+              disabled={isRequesting}
             >
-              <Text className="text-base font-bold text-white">{t('permissions.allowAccess')}</Text>
+              <Text className="text-base font-bold text-white">
+                {isRequesting ? t('permissions.requestingAccess') : t('permissions.allowAccess')}
+              </Text>
             </TouchableOpacity>
             <TouchableOpacity
               className="h-10 w-full items-center justify-center"


### PR DESCRIPTION
## What does this PR do?

- Turns the permissions screen into a real permission step instead of a visual-only screen. Pressing `Allow Access` now actually requests camera and microphone permissions before continuing to the dashboard.

- The screen also gives clearer feedback during the request flow: the button shows a loading state while access is being requested, and the user stays on the same screen with an error message if permission is denied.


## Which package(s) does it touch?

- `sozia.client.ui` — updates the permissions screen flow and user feedback  
- `ui/i18n` — adds permission request/loading/error strings

## How to test

1. Open the app and go through the `Sign Up -> Permissions` flow.
2. On the permissions screen, press `Allow Access`.
3. Confirm that the OS camera/microphone permission prompt appears.
4. Deny access and verify the app stays on the same screen and shows an error message.
5. Grant access and verify the app continues to the dashboard.
6. Check that the button shows a temporary loading/requesting state while permissions are being requested.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [ ] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally