### PR TITLE
chore(client/common): adapted client and common code to match sozia.server LLD deviations 

### DIFF
--- a/__tests__/config/Configuration.test.ts
+++ b/__tests__/config/Configuration.test.ts
@@ -81,4 +81,23 @@ describe('Configuration', () => {
 
     expect(cfg.get('defaultPath')).toBe(ModalityPath.SPEECH);
   });
+
+  test('apiKey defaults to empty string', async () => {
+    const s = makeStorage();
+    const cfg = new Configuration(s);
+    await cfg.load();
+
+    expect(cfg.get('apiKey')).toBe('');
+  });
+
+  test('apiKey round-trips through set/get', () => {
+    const s = makeStorage();
+    const cfg = new Configuration(s);
+
+    cfg.set('apiKey', 'sk-test-abc123');
+    expect(cfg.get('apiKey')).toBe('sk-test-abc123');
+
+    const persisted = JSON.parse(s.data[KEY]);
+    expect(persisted.apiKey).toBe('sk-test-abc123');
+  });
 });

--- a/__tests__/config/DiagnosticsLogger.test.ts
+++ b/__tests__/config/DiagnosticsLogger.test.ts
@@ -35,6 +35,7 @@ function makeConfig(enabled: boolean): IConfigurationManager {
     maxReconnectAttempts: 5,
     diagnosticsEnabled: enabled,
     vadSensitivity: 'medium',
+    apiKey: '',
   };
 
   return {

--- a/__tests__/transmission/FeatureSerializer.test.ts
+++ b/__tests__/transmission/FeatureSerializer.test.ts
@@ -138,23 +138,33 @@ describe('FeatureSerializer', () => {
 
   describe('sessionInit()', () => {
     it('produces type "session_init"', () => {
-      const result = JSON.parse(serializer.sessionInit('session-1', ModalityPath.SPEECH));
+      const result = JSON.parse(serializer.sessionInit('session-1', ModalityPath.SPEECH, ''));
       expect(result.type).toBe('session_init');
     });
 
     it('includes sessionId', () => {
-      const result = JSON.parse(serializer.sessionInit('session-abc', ModalityPath.SPEECH));
+      const result = JSON.parse(serializer.sessionInit('session-abc', ModalityPath.SPEECH, ''));
       expect(result.sessionId).toBe('session-abc');
     });
 
     it('includes activePath for SPEECH', () => {
-      const result = JSON.parse(serializer.sessionInit('s', ModalityPath.SPEECH));
+      const result = JSON.parse(serializer.sessionInit('s', ModalityPath.SPEECH, ''));
       expect(result.activePath).toBe(ModalityPath.SPEECH);
     });
 
     it('includes activePath for SIGN', () => {
-      const result = JSON.parse(serializer.sessionInit('s', ModalityPath.SIGN));
+      const result = JSON.parse(serializer.sessionInit('s', ModalityPath.SIGN, ''));
       expect(result.activePath).toBe(ModalityPath.SIGN);
+    });
+
+    it('includes api_key in the payload', () => {
+      const result = JSON.parse(serializer.sessionInit('s', ModalityPath.SPEECH, 'my-secret-key'));
+      expect(result.api_key).toBe('my-secret-key');
+    });
+
+    it('includes api_key as empty string when not set', () => {
+      const result = JSON.parse(serializer.sessionInit('s', ModalityPath.SPEECH, ''));
+      expect(result.api_key).toBe('');
     });
   });
 

--- a/__tests__/transmission/TransmissionManager.test.ts
+++ b/__tests__/transmission/TransmissionManager.test.ts
@@ -106,8 +106,8 @@ function makeManager(opts: { maxAttempts?: number } = {}): {
 }
 
 /** Connect and await the ready ack — leaves manager in RUNNING state. */
-async function connectManager(manager: TransmissionManager): Promise<FakeWebSocket> {
-  const promise = manager.connect('session-1', ModalityPath.SPEECH);
+async function connectManager(manager: TransmissionManager, apiKey = ''): Promise<FakeWebSocket> {
+  const promise = manager.connect('session-1', ModalityPath.SPEECH, apiKey);
   const ws = FakeWebSocket.lastInstance!;
   ws.simulateOpen();
   ws.simulateReady();
@@ -159,16 +159,16 @@ describe('TransmissionManager', () => {
   describe('connect()', () => {
     it('resolves when server sends ready ack', async () => {
       const { manager } = makeManager();
-      const promise = manager.connect('session-1', ModalityPath.SPEECH);
+      const promise = manager.connect('session-1', ModalityPath.SPEECH, '');
       const ws = FakeWebSocket.lastInstance!;
       ws.simulateOpen();
       ws.simulateReady();
       await expect(promise).resolves.toBeUndefined();
     });
 
-    it('sends session_init with sessionId and activePath on open', async () => {
+    it('sends session_init with sessionId, activePath, and api_key on open', async () => {
       const { manager } = makeManager();
-      const promise = manager.connect('session-1', ModalityPath.SIGN);
+      const promise = manager.connect('session-1', ModalityPath.SIGN, 'test-key');
       const ws = FakeWebSocket.lastInstance!;
       ws.simulateOpen();
 
@@ -176,6 +176,20 @@ describe('TransmissionManager', () => {
       expect(msg.type).toBe('session_init');
       expect(msg.sessionId).toBe('session-1');
       expect(msg.activePath).toBe(ModalityPath.SIGN);
+      expect(msg.api_key).toBe('test-key');
+
+      ws.simulateReady();
+      await promise;
+    });
+
+    it('sends api_key as empty string when not provided', async () => {
+      const { manager } = makeManager();
+      const promise = manager.connect('session-1', ModalityPath.SPEECH, '');
+      const ws = FakeWebSocket.lastInstance!;
+      ws.simulateOpen();
+
+      const msg = JSON.parse(ws.sentMessages[0]);
+      expect(msg.api_key).toBe('');
 
       ws.simulateReady();
       await promise;
@@ -183,7 +197,7 @@ describe('TransmissionManager', () => {
 
     it('rejects after 10 s if server never sends ready', async () => {
       const { manager } = makeManager();
-      const promise = manager.connect('session-1', ModalityPath.SPEECH);
+      const promise = manager.connect('session-1', ModalityPath.SPEECH, '');
       const ws = FakeWebSocket.lastInstance!;
       ws.simulateOpen();
       // No ready ack
@@ -194,21 +208,21 @@ describe('TransmissionManager', () => {
     it('connects to the provided serverUrl', () => {
       const store = new TranscriptStore();
       const manager = new TransmissionManager('wss://custom.host/ws', store, jest.fn());
-      manager.connect('session-1', ModalityPath.SPEECH);
+      manager.connect('session-1', ModalityPath.SPEECH, '');
       expect(FakeWebSocket.lastInstance!.url).toBe('wss://custom.host/ws');
     });
 
     it('rejects immediately when serverUrl is a placeholder like "wss://..."', async () => {
       const store = new TranscriptStore();
       const manager = new TransmissionManager('wss://...', store, jest.fn());
-      await expect(manager.connect('session-1', ModalityPath.SPEECH)).rejects.toThrow('invalid server URL');
+      await expect(manager.connect('session-1', ModalityPath.SPEECH, '')).rejects.toThrow('invalid server URL');
       expect(FakeWebSocket.lastInstance).toBeNull(); // no WebSocket created
     });
 
     it('rejects immediately when serverUrl has no ws:// or wss:// scheme', async () => {
       const store = new TranscriptStore();
       const manager = new TransmissionManager('https://example.com', store, jest.fn());
-      await expect(manager.connect('session-1', ModalityPath.SPEECH)).rejects.toThrow('invalid server URL');
+      await expect(manager.connect('session-1', ModalityPath.SPEECH, '')).rejects.toThrow('invalid server URL');
     });
   });
 
@@ -239,7 +253,7 @@ describe('TransmissionManager', () => {
 
     it('buffers features when not yet connected (socket CONNECTING)', () => {
       const { manager } = makeManager();
-      manager.connect('session-1', ModalityPath.SPEECH);
+      manager.connect('session-1', ModalityPath.SPEECH, '');
       // Socket created but not opened yet
       const ws = FakeWebSocket.lastInstance!;
       expect(ws.readyState).toBe(FakeWebSocket.CONNECTING);
@@ -251,7 +265,7 @@ describe('TransmissionManager', () => {
 
     it('flushes buffered features when ready ack arrives', async () => {
       const { manager } = makeManager();
-      const promise = manager.connect('session-1', ModalityPath.SPEECH);
+      const promise = manager.connect('session-1', ModalityPath.SPEECH, '');
       const ws = FakeWebSocket.lastInstance!;
 
       // Buffer a chunk before the socket is ready
@@ -272,7 +286,7 @@ describe('TransmissionManager', () => {
 
     it('drops the oldest entry when buffer exceeds 200 items', async () => {
       const { manager } = makeManager();
-      const promise = manager.connect('session-1', ModalityPath.SPEECH);
+      const promise = manager.connect('session-1', ModalityPath.SPEECH, '');
       const ws = FakeWebSocket.lastInstance!;
 
       // Push 201 chunks — chunk #0 should be dropped
@@ -355,7 +369,7 @@ describe('TransmissionManager', () => {
       manager.disconnect(); // clears buffer + stops reconnect
 
       // New connect should not flush the old chunk
-      const promise2 = manager.connect('session-2', ModalityPath.SPEECH);
+      const promise2 = manager.connect('session-2', ModalityPath.SPEECH, '');
       const ws2 = FakeWebSocket.lastInstance!;
       ws2.simulateOpen();
       ws2.simulateReady();
@@ -533,6 +547,74 @@ describe('TransmissionManager', () => {
       ws.onmessage?.({ data: JSON.stringify({ type: 'transcript_segment', segmentId: 'seg-1' }) });
 
       expect(store.size).toBe(0);
+    });
+
+    it('routes session_status to onSessionStatus callback', async () => {
+      const onSessionStatus = jest.fn();
+      const store = new TranscriptStore();
+      const manager = new TransmissionManager('wss://test.sozia', store, jest.fn(), 5, onSessionStatus);
+      const ws = await connectManager(manager);
+
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: 'session_status',
+          session_id: 'session-1',
+          state: 'RUNNING',
+          message: 'Model warm-up complete',
+        }),
+      });
+
+      expect(onSessionStatus).toHaveBeenCalledTimes(1);
+      expect(onSessionStatus).toHaveBeenCalledWith({
+        session_id: 'session-1',
+        state: 'RUNNING',
+        message: 'Model warm-up complete',
+      });
+    });
+
+    it('routes error to onServerError callback', async () => {
+      const onServerError = jest.fn();
+      const store = new TranscriptStore();
+      const manager = new TransmissionManager('wss://test.sozia', store, jest.fn(), 5, undefined, onServerError);
+      const ws = await connectManager(manager);
+
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: 'error',
+          session_id: 'session-1',
+          code: 4001,
+          message: 'Authentication failed',
+        }),
+      });
+
+      expect(onServerError).toHaveBeenCalledTimes(1);
+      expect(onServerError).toHaveBeenCalledWith({
+        session_id: 'session-1',
+        code: 4001,
+        message: 'Authentication failed',
+      });
+    });
+
+    it('does not throw on session_status when no callback is provided', async () => {
+      const { manager } = makeManager();
+      const ws = await connectManager(manager);
+
+      expect(() => {
+        ws.onmessage?.({
+          data: JSON.stringify({ type: 'session_status', session_id: 'session-1', state: 'RUNNING', message: '' }),
+        });
+      }).not.toThrow();
+    });
+
+    it('does not throw on error when no callback is provided', async () => {
+      const { manager } = makeManager();
+      const ws = await connectManager(manager);
+
+      expect(() => {
+        ws.onmessage?.({
+          data: JSON.stringify({ type: 'error', session_id: 'session-1', code: 4002, message: 'Bad session' }),
+        });
+      }).not.toThrow();
     });
   });
 });

--- a/sozia/client/config/Configuration.ts
+++ b/sozia/client/config/Configuration.ts
@@ -13,6 +13,8 @@ export interface AppConfig {
   maxReconnectAttempts: number;
   diagnosticsEnabled: boolean;
   vadSensitivity: 'low' | 'medium' | 'high';
+  /** API key sent in the `session_init` message (DEV-02). Empty string = no auth. */
+  apiKey: string;
 }
 
 export interface IConfigurationManager {
@@ -40,6 +42,7 @@ const DEFAULT_CONFIG: AppConfig = {
   maxReconnectAttempts: 5,
   diagnosticsEnabled: false,
   vadSensitivity: 'medium',
+  apiKey: '',
 };
 
 function getBrowserStorage(): KeyValueStorage | null {
@@ -82,6 +85,7 @@ function mergeWithDefaults(raw: unknown): AppConfig {
       input.vadSensitivity === 'low' || input.vadSensitivity === 'high'
         ? input.vadSensitivity
         : 'medium',
+    apiKey: typeof input.apiKey === 'string' ? input.apiKey : '',
   };
 }
 

--- a/sozia/client/transmission/FeatureSerializer.ts
+++ b/sozia/client/transmission/FeatureSerializer.ts
@@ -36,8 +36,8 @@ export class FeatureSerializer {
     return JSON.stringify({ type: 'pipeline_health', ...payload });
   }
 
-  sessionInit(sessionId: string, activePath: ModalityPath): string {
-    return JSON.stringify({ type: 'session_init', sessionId, activePath });
+  sessionInit(sessionId: string, activePath: ModalityPath, apiKey: string): string {
+    return JSON.stringify({ type: 'session_init', sessionId, activePath, api_key: apiKey });
   }
 
   sessionEnd(sessionId: string): string {

--- a/sozia/client/transmission/TransmissionManager.ts
+++ b/sozia/client/transmission/TransmissionManager.ts
@@ -1,4 +1,12 @@
-import type { LandmarkFrame, AudioFeatureChunk, PipelineHealth, ModalityPath } from '@common/models';
+import type {
+  LandmarkFrame,
+  AudioFeatureChunk,
+  PipelineHealth,
+  ModalityPath,
+  SessionState,
+  SessionStatusMessage,
+  ErrorMessage,
+} from '@common/models';
 import type { TranscriptStore } from '@/store/TranscriptStore';
 import { FeatureSerializer } from './FeatureSerializer';
 import { SegmentReceiver } from './SegmentReceiver';
@@ -70,6 +78,8 @@ export class TransmissionManager {
   private readonly store: TranscriptStore;
   private readonly onConnectionLost: () => void;
   private readonly maxReconnectAttempts: number;
+  private readonly onSessionStatus: ((msg: SessionStatusMessage) => void) | undefined;
+  private readonly onServerError: ((msg: ErrorMessage) => void) | undefined;
 
   private readonly serializer = new FeatureSerializer();
   private readonly receiver = new SegmentReceiver();
@@ -77,6 +87,7 @@ export class TransmissionManager {
   private socket: WebSocketInstance | null = null;
   private sessionId: string | null = null;
   private activePath: ModalityPath | null = null;
+  private apiKey: string = '';
 
   private sendBuffer: string[] = [];
   private reconnectAttempts = 0;
@@ -89,18 +100,22 @@ export class TransmissionManager {
     store: TranscriptStore,
     onConnectionLost: () => void,
     maxReconnectAttempts = 5,
+    onSessionStatus?: (msg: SessionStatusMessage) => void,
+    onServerError?: (msg: ErrorMessage) => void,
   ) {
     this.serverUrl = serverUrl;
     this.store = store;
     this.onConnectionLost = onConnectionLost;
     this.maxReconnectAttempts = maxReconnectAttempts;
+    this.onSessionStatus = onSessionStatus;
+    this.onServerError = onServerError;
   }
 
   /**
    * Opens a WebSocket, sends `session_init`, and resolves once the server
    * replies with a `ready` ack. Rejects after 10 s if no ack is received.
    */
-  connect(sessionId: string, activePath: ModalityPath): Promise<void> {
+  connect(sessionId: string, activePath: ModalityPath, apiKey: string): Promise<void> {
     if (!isValidWsUrl(this.serverUrl)) {
       return Promise.reject(
         new Error(`TransmissionManager: invalid server URL "${this.serverUrl}"`)
@@ -108,6 +123,7 @@ export class TransmissionManager {
     }
     this.sessionId = sessionId;
     this.activePath = activePath;
+    this.apiKey = apiKey;
     this.reconnectAttempts = 0;
     return this._openInitialSocket();
   }
@@ -210,7 +226,7 @@ export class TransmissionManager {
    */
   private _attachSocketHandlers(socket: WebSocketInstance): void {
     socket.onopen = () => {
-      this._sendRaw(this.serializer.sessionInit(this.sessionId!, this.activePath!));
+      this._sendRaw(this.serializer.sessionInit(this.sessionId!, this.activePath!, this.apiKey));
       // Buffer is flushed once the server sends "ready" (see _handleMessage).
     };
 
@@ -264,31 +280,53 @@ export class TransmissionManager {
       return;
     }
 
+    let parsed: unknown;
     try {
-      const parsed = JSON.parse(data) as unknown;
-      if (
-        typeof parsed === 'object' &&
-        parsed !== null &&
-        (parsed as Record<string, unknown>)['type'] === 'ready'
-      ) {
-        // Reset on every ready ack, including reconnects.
-        this.reconnectAttempts = 0;
-
-        if (this.readyResolver !== null) {
-          clearTimeout(this.connectTimeout!);
-          this.connectTimeout = null;
-
-          const { resolve } = this.readyResolver;
-          this.readyResolver = null;
-          resolve();
-        }
-
-        // Always flush here — both the initial connect and every reconnect
-        // gate the buffer flush on the server's ready ack.
-        this._flushBuffer();
-      }
+      parsed = JSON.parse(data);
     } catch {
       // Malformed JSON — ignore.
+      return;
+    }
+
+    if (typeof parsed !== 'object' || parsed === null) return;
+
+    const msg = parsed as Record<string, unknown>;
+    const type = msg['type'];
+
+    if (type === 'ready') {
+      // Reset on every ready ack, including reconnects.
+      this.reconnectAttempts = 0;
+
+      if (this.readyResolver !== null) {
+        clearTimeout(this.connectTimeout!);
+        this.connectTimeout = null;
+
+        const { resolve } = this.readyResolver;
+        this.readyResolver = null;
+        resolve();
+      }
+
+      // Always flush here — both the initial connect and every reconnect
+      // gate the buffer flush on the server's ready ack.
+      this._flushBuffer();
+      return;
+    }
+
+    if (type === 'session_status' && this.onSessionStatus !== undefined) {
+      this.onSessionStatus({
+        session_id: msg['session_id'] as string,
+        state: msg['state'] as SessionState,
+        message: msg['message'] as string,
+      });
+      return;
+    }
+
+    if (type === 'error' && this.onServerError !== undefined) {
+      this.onServerError({
+        session_id: msg['session_id'] as string,
+        code: msg['code'] as number,
+        message: msg['message'] as string,
+      });
     }
   }
 

--- a/sozia/client/ui/controller/SessionController.tsx
+++ b/sozia/client/ui/controller/SessionController.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
-import { ModalityPath, SessionState, type PipelineHealth } from '@common/models';
+import { ModalityPath, SessionState, type PipelineHealth, type SessionStatusMessage } from '@common/models';
 import type { DeviceHandle } from '@/device';
 import { ExpoAudioPipeline } from '@/pipeline/audio';
 import { VideoPipeline } from '@/pipeline/video';
@@ -144,11 +144,21 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
 
       const serverUrl = config.current.get('serverUrl') ?? 'ws://localhost:8080';
       const maxReconnectAttempts = config.current.get('maxReconnectAttempts') ?? 5;
+      const apiKey = config.current.get('apiKey') ?? '';
+
+      const handleSessionStatus = (msg: SessionStatusMessage) => {
+        if (msg.state === SessionState.ERROR) {
+          actions.onConnectionLost();
+        }
+      };
+
       transmissionManager.current = new TransmissionManager(
         serverUrl,
         store,
         actions.onConnectionLost,
         maxReconnectAttempts,
+        handleSessionStatus,
+        () => { actions.onConnectionLost(); },
       );
 
       if (path === ModalityPath.SPEECH) {
@@ -159,7 +169,7 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
 
       // Connect in the background — the 50-frame send buffer holds frames
       // produced during the connection window. onConnectionLost handles failure.
-      void transmissionManager.current.connect(newSessionId, path)
+      void transmissionManager.current.connect(newSessionId, path, apiKey)
         .catch(() => { actions.onConnectionLost(); });
 
       setState(SessionState.RUNNING);

--- a/sozia/common/models/index.ts
+++ b/sozia/common/models/index.ts
@@ -106,6 +106,26 @@ export interface ModalityResult {
   inferenceLatencyMs: number;
 }
 
+/** Server→client lifecycle notification (DEV-01). */
+export interface SessionStatusMessage {
+  /** UUID v4. Matches the active session. */
+  session_id: string;
+  /** Current state reported by the server. */
+  state: SessionState;
+  /** Human-readable description (e.g. warm-up progress, auth rejection). */
+  message: string;
+}
+
+/** Server→client error notification (DEV-01). Codes 4001–4004. */
+export interface ErrorMessage {
+  /** UUID v4. Matches the active session. */
+  session_id: string;
+  /** Numeric error code (4001–4004). */
+  code: number;
+  /** Human-readable error description. */
+  message: string;
+}
+
 /** Time-aligned transcript text with metadata (LLD §3.1.2). */
 export interface TranscriptSegment {
   /** UUID v4. Globally unique. */


### PR DESCRIPTION
## What does this PR do?

Adapt sozia.server deviations in client:

- Implement API key authentication in the `session_init` message (DEV-02)
- Add support for handling server-sent `session_status` and `error` messages (DEV-01)
- Update `TransmissionManager` to support lifecycle callbacks and propagate server errors to the UI

## Which package(s) does it touch?

- sozia.common
- sozia.client.ui
- sozia.client.transmission
- sozia.client.configuration

## How to test

- `npm run check`

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally