### PR TITLE
chore(audio-pipeline): completed audio pipeline and set up eas dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ After Expo starts, you can:
 - press `a` for Android
 - press `i` for iOS
 - press `w` for web
-- scan the QR code with Expo Go
+- scan the QR code with the EAS dev client (not Expo Go — see Native Development section below)
 
 ## Available Scripts
 
@@ -66,6 +66,20 @@ npx jest --testNamePattern="export"                    # by test name
 ```
 
 Unit tests live under `__tests__/` mirroring the `src/` structure (`.ts` only, no `.tsx`).
+
+## Native Development (EAS Dev Build)
+
+Expo Go will not work — native modules require a custom dev client.
+
+```bash
+# Build and install the dev client on your device (once per native change)
+eas build --profile development --platform android   # or ios
+
+# Then start Metro and scan the QR with the installed dev client
+npm run start
+```
+
+To view device logs: shake the phone → React Native dev menu → Open DevTools.
 
 ## Notes
 

--- a/__tests__/pipeline/audio/AudioPipeline.test.ts
+++ b/__tests__/pipeline/audio/AudioPipeline.test.ts
@@ -314,18 +314,21 @@ describe('IAudioPipeline.setVadSensitivity()', () => {
 });
 
 // ---------------------------------------------------------------------------
-// TP-CLIENT-AUDIO-007: RecordingPresets shape guard
+// TP-CLIENT-AUDIO-007: @siteed/expo-audio-studio RecordingConfig shape guard
 // ---------------------------------------------------------------------------
 
-describe('RecordingPresets.HIGH_QUALITY shape', () => {
-  it('TP-CLIENT-AUDIO-007a: has the top-level keys flattenRecordingOptions depends on', () => {
-    // Read the declaration source to verify the RecordingOptions shape hasn't changed.
-    // Direct require() of expo-audio fails under Jest (ESM), so we inspect the .d.ts.
+describe('@siteed/expo-audio-studio RecordingConfig shape', () => {
+  it('TP-CLIENT-AUDIO-007a: RecordingConfig has the fields ExpoAudioPipeline depends on', () => {
+    // ExpoAudioPipeline uses: sampleRate, channels, encoding, streamFormat,
+    // interval, output, onAudioStream. Inspect the .d.ts to catch upstream renames.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const fs = jest.requireActual<any>('fs');
-    const typeDef = fs.readFileSync('node_modules/expo-audio/build/RecordingConstants.d.ts', 'utf8') as string;
+    const typeDef = fs.readFileSync(
+      'node_modules/@siteed/audio-studio/build/types/AudioStudio.types.d.ts',
+      'utf8',
+    ) as string;
 
-    for (const key of ['extension', 'sampleRate', 'numberOfChannels', 'bitRate', 'ios', 'android', 'web']) {
+    for (const key of ['sampleRate', 'channels', 'encoding', 'streamFormat', 'interval', 'output', 'onAudioStream']) {
       expect(typeDef).toContain(key);
     }
   });

--- a/__tests__/pipeline/audio/ExpoAudioPipeline.test.ts
+++ b/__tests__/pipeline/audio/ExpoAudioPipeline.test.ts
@@ -1,0 +1,419 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Unit tests — ExpoAudioPipeline
+ *
+ * Verifies the concrete audio pipeline behaviour:
+ * - platform-specific module resolution (_resolveRecorder)
+ * - correct delegation to startRecording / stopRecording / pauseRecording / resumeRecording
+ * - no synchronous throw when recording methods are absent (web factory path)
+ * - frame processing and chunk forwarding
+ *
+ * Test plan reference: TP-CLIENT-EXPOPIPELINE-001 through TP-CLIENT-EXPOPIPELINE-005
+ */
+
+import { ExpoAudioPipeline } from '@/pipeline/audio/ExpoAudioPipeline';
+import { AudioChunker } from '@/pipeline/audio/AudioChunker';
+
+// ---------------------------------------------------------------------------
+// Mock @siteed/audio-studio — shape varies by test case (native vs web)
+// ---------------------------------------------------------------------------
+
+const mockStartRecording = jest.fn().mockResolvedValue(undefined);
+const mockStopRecording = jest.fn().mockResolvedValue(undefined);
+const mockPauseRecording = jest.fn().mockResolvedValue(undefined);
+const mockResumeRecording = jest.fn().mockResolvedValue(undefined);
+
+// Default mock: native-like object with all recording methods.
+jest.mock('@siteed/audio-studio', () => ({
+  AudioStudioModule: {
+    startRecording: (...args: unknown[]) => mockStartRecording(...args),
+    stopRecording: () => mockStopRecording(),
+    pauseRecording: () => mockPauseRecording(),
+    resumeRecording: () => mockResumeRecording(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock expo-modules-core LegacyEventEmitter — used for native audio events
+// ---------------------------------------------------------------------------
+
+type NativeListener = (event: { pcmFloat32?: Float32Array | number[]; buffer?: Float32Array }) => void;
+let capturedNativeListener: NativeListener | null = null;
+const mockNativeRemove = jest.fn();
+const mockNativeAddListener = jest.fn().mockImplementation(
+  (_event: string, cb: NativeListener) => {
+    capturedNativeListener = cb;
+    return { remove: mockNativeRemove };
+  },
+);
+
+jest.mock('expo-modules-core', () => ({
+  LegacyEventEmitter: jest.fn().mockImplementation(() => ({
+    addListener: mockNativeAddListener,
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeChunker(): AudioChunker {
+  return new AudioChunker();
+}
+
+function makeTx() {
+  return { sendFeatures: jest.fn() };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  capturedNativeListener = null;
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-EXPOPIPELINE-001: start() delegates to startRecording
+// ---------------------------------------------------------------------------
+
+describe('ExpoAudioPipeline.start()', () => {
+  it('TP-CLIENT-EXPOPIPELINE-001a: calls startRecording with the correct config shape', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-001');
+
+    expect(mockStartRecording).toHaveBeenCalledTimes(1);
+    const config = mockStartRecording.mock.calls[0][0] as Record<string, unknown>;
+    expect(config.sampleRate).toBe(16_000);
+    expect(config.channels).toBe(1);
+    expect(config.encoding).toBe('pcm_16bit');
+    expect(config.streamFormat).toBe('float32');
+    // onAudioStream is NOT passed in config — native delivers PCM via LegacyEventEmitter 'AudioData' events
+    expect(config.onAudioStream).toBeUndefined();
+
+    pipeline.stop();
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-001b: calling start() twice is a no-op for the second call', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-001');
+    await pipeline.start('session-002'); // should be ignored
+
+    expect(mockStartRecording).toHaveBeenCalledTimes(1);
+
+    pipeline.stop();
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-001c: getHealth() returns available=true after start()', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-001');
+
+    expect(pipeline.getHealth().available).toBe(true);
+    expect(pipeline.getHealth().sessionId).toBe('session-001');
+
+    pipeline.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-EXPOPIPELINE-002: stop() lifecycle
+// ---------------------------------------------------------------------------
+
+describe('ExpoAudioPipeline.stop()', () => {
+  it('TP-CLIENT-EXPOPIPELINE-002a: calls stopRecording after a started session', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-001');
+    pipeline.stop();
+
+    expect(mockStopRecording).toHaveBeenCalledTimes(1);
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-002a-native-sub: stop() removes the native AudioData subscription', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-001');
+    pipeline.stop();
+
+    expect(mockNativeRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-002b: does NOT call stopRecording when recording was never started', () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    pipeline.stop(); // never called start()
+
+    expect(mockStopRecording).not.toHaveBeenCalled();
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-002c: getHealth() returns available=false after stop()', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-001');
+    pipeline.stop();
+
+    const health = pipeline.getHealth();
+    expect(health.available).toBe(false);
+    expect(health.sessionId).toBe('');
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-002d: stop() does not throw even if stopRecording rejects', async () => {
+    mockStopRecording.mockRejectedValueOnce(new Error('native error'));
+
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-001');
+
+    expect(() => pipeline.stop()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-EXPOPIPELINE-003: pause() / resume()
+// ---------------------------------------------------------------------------
+
+describe('ExpoAudioPipeline.pause() / resume()', () => {
+  it('TP-CLIENT-EXPOPIPELINE-003a: pause() calls pauseRecording when recording is active', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-001');
+    pipeline.pause();
+
+    expect(mockPauseRecording).toHaveBeenCalledTimes(1);
+
+    pipeline.stop();
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-003b: resume() calls resumeRecording after pause', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-001');
+    pipeline.pause();
+    pipeline.resume();
+
+    expect(mockResumeRecording).toHaveBeenCalledTimes(1);
+
+    pipeline.stop();
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-003c: pause() is a no-op when not running', () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    pipeline.pause(); // never started
+
+    expect(mockPauseRecording).not.toHaveBeenCalled();
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-003d: resume() is a no-op when not paused', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-001');
+    pipeline.resume(); // not paused
+
+    expect(mockResumeRecording).not.toHaveBeenCalled();
+
+    pipeline.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-EXPOPIPELINE-004: web factory path — no synchronous throws
+// ---------------------------------------------------------------------------
+
+describe('ExpoAudioPipeline web factory path', () => {
+  // Re-mock AudioStudioModule as a web factory function (no recording methods
+  // on the function itself — they live on the returned AudioStudioWeb instance).
+  const webStartRecording = jest.fn().mockResolvedValue(undefined);
+  const webStopRecording = jest.fn().mockResolvedValue(undefined);
+  const webPauseRecording = jest.fn().mockResolvedValue(undefined);
+  const webResumeRecording = jest.fn().mockResolvedValue(undefined);
+
+  // Captured AudioData listener so tests can fire fake audio events
+  let capturedAudioDataListener: ((e: { buffer: Float32Array }) => void) | null = null;
+  const webAddListener = jest.fn().mockImplementation(
+    (_event: string, cb: (e: { buffer: Float32Array }) => void) => {
+      capturedAudioDataListener = cb;
+      return { remove: jest.fn() };
+    },
+  );
+
+  let webInstance: {
+    startRecording: jest.Mock;
+    stopRecording: jest.Mock;
+    pauseRecording: jest.Mock;
+    resumeRecording: jest.Mock;
+    addListener: jest.Mock;
+  };
+
+  let originalModule: unknown;
+
+  beforeEach(() => {
+    capturedAudioDataListener = null;
+    webInstance = {
+      startRecording: webStartRecording,
+      stopRecording: webStopRecording,
+      pauseRecording: webPauseRecording,
+      resumeRecording: webResumeRecording,
+      addListener: webAddListener,
+    };
+
+    // Patch the module's AudioStudioModule export to the web factory shape
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('@siteed/audio-studio') as { AudioStudioModule: unknown };
+    originalModule = mod.AudioStudioModule;
+
+    const factory = () => webInstance;
+    // Factory has NO startRecording — matches the real web behaviour
+    mod.AudioStudioModule = factory;
+
+    jest.clearAllMocks();
+    capturedAudioDataListener = null;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('@siteed/audio-studio') as { AudioStudioModule: unknown };
+    mod.AudioStudioModule = originalModule;
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-004a: start() delegates to the web instance, not the factory itself', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-web');
+
+    expect(webStartRecording).toHaveBeenCalledTimes(1);
+
+    pipeline.stop();
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-004b: start() subscribes to AudioData events on the web instance', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-web');
+
+    expect(webAddListener).toHaveBeenCalledWith('AudioData', expect.any(Function));
+
+    pipeline.stop();
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-004c: AudioData events drive frame listeners on web', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    const frames: unknown[] = [];
+    pipeline.onFrame((f) => frames.push(f));
+
+    await pipeline.start('session-web');
+
+    // Fire the AudioData event directly — simulates what AudioStudioWeb emits
+    capturedAudioDataListener?.({ buffer: new Float32Array(400).fill(0.1) });
+
+    expect(frames).toHaveLength(1);
+    const frame = frames[0] as { coefficients: number[]; energy: number };
+    expect(frame.coefficients).toHaveLength(13);
+    expect(typeof frame.energy).toBe('number');
+
+    pipeline.stop();
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-004d: stop() removes the AudioData subscription', async () => {
+    const removeMock = jest.fn();
+    webAddListener.mockReturnValueOnce({ remove: removeMock });
+
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-web');
+    pipeline.stop();
+
+    expect(removeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-004e: stop() does not throw on the web factory path', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-web');
+
+    expect(() => pipeline.stop()).not.toThrow();
+    expect(webStopRecording).toHaveBeenCalledTimes(1);
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-004f: stop() does not throw even when stopRecording is absent on the instance', async () => {
+    // Edge case: instance exists but has no stopRecording (should never happen
+    // in practice, but guards against partial implementations).
+    webInstance = {
+      startRecording: webStartRecording,
+      stopRecording: undefined as unknown as jest.Mock,
+      pauseRecording: undefined as unknown as jest.Mock,
+      resumeRecording: undefined as unknown as jest.Mock,
+      addListener: webAddListener,
+    };
+
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    await pipeline.start('session-web');
+
+    expect(() => pipeline.stop()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TP-CLIENT-EXPOPIPELINE-005: onFrame() and chunk forwarding
+// ---------------------------------------------------------------------------
+
+describe('ExpoAudioPipeline.onFrame() and chunk forwarding', () => {
+  it('TP-CLIENT-EXPOPIPELINE-005a: native AudioData event drives frame listeners via real MFCC', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    const frames: unknown[] = [];
+    pipeline.onFrame((f) => frames.push(f));
+
+    await pipeline.start('session-001');
+
+    // Native PCM is delivered via the LegacyEventEmitter 'AudioData' event,
+    // not via onAudioStream in the config.
+    expect(capturedNativeListener).not.toBeNull();
+
+    // Feed exactly 400 samples (one full frame at 16 kHz / 25 ms)
+    capturedNativeListener!({ pcmFloat32: new Float32Array(400).fill(0.1) });
+
+    expect(frames).toHaveLength(1);
+    const frame = frames[0] as { coefficients: number[]; energy: number; timestampMs: number };
+    expect(frame.coefficients).toHaveLength(13);
+    expect(typeof frame.energy).toBe('number');
+    expect(isFinite(frame.energy)).toBe(true);
+
+    pipeline.stop();
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-005a-ios: iOS number[] pcmFloat32 is accepted', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    const frames: unknown[] = [];
+    pipeline.onFrame((f) => frames.push(f));
+
+    await pipeline.start('session-001');
+
+    expect(capturedNativeListener).not.toBeNull();
+    // iOS delivers pcmFloat32 as a plain number[] — must be converted to Float32Array
+    capturedNativeListener!({ pcmFloat32: Array.from({ length: 400 }, () => 0.1) });
+
+    expect(frames).toHaveLength(1);
+
+    pipeline.stop();
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-005b: onFrame unsubscribe stops delivery', async () => {
+    const pipeline = new ExpoAudioPipeline(makeChunker());
+    const frames: unknown[] = [];
+    const unsub = pipeline.onFrame((f) => frames.push(f));
+
+    await pipeline.start('session-001');
+
+    unsub();
+    capturedNativeListener!({ pcmFloat32: new Float32Array(400).fill(0.05) });
+
+    expect(frames).toHaveLength(0);
+
+    pipeline.stop();
+  });
+
+  it('TP-CLIENT-EXPOPIPELINE-005c: chunks are forwarded to tx.sendFeatures when tx is provided', async () => {
+    // Use a chunker configured for a very small window (1 frame) so we get a
+    // chunk immediately on the first push without waiting for 20 frames.
+    const chunker = new AudioChunker(25 /* chunkDurationMs = 1 frame */);
+    const tx = makeTx();
+    const pipeline = new ExpoAudioPipeline(chunker);
+
+    await pipeline.start('session-001', {}, tx as never);
+
+    expect(capturedNativeListener).not.toBeNull();
+
+    // Feed a loud signal so VAD passes (energy > -40 dBFS)
+    capturedNativeListener!({ pcmFloat32: new Float32Array(400).fill(0.9) });
+
+    expect(tx.sendFeatures).toHaveBeenCalledTimes(1);
+
+    pipeline.stop();
+  });
+});

--- a/__tests__/pipeline/audio/MfccComputer.test.ts
+++ b/__tests__/pipeline/audio/MfccComputer.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests — MfccComputer
+ *
+ * Validates the pure-JS MFCC pipeline: shape, finite-ness, energy sensitivity,
+ * and determinism. Does not assert exact coefficient values (they depend on
+ * the filterbank, which is validated structurally rather than numerically).
+ */
+
+import { MfccComputer, frameLogEnergy } from '@/pipeline/audio/MfccComputer';
+
+const FRAME_SIZE = 400; // 25 ms at 16 kHz
+
+function sineFrame(frequency: number, sampleRate = 16_000): Float32Array {
+  const samples = new Float32Array(FRAME_SIZE);
+  for (let i = 0; i < FRAME_SIZE; i++) {
+    samples[i] = Math.sin((2 * Math.PI * frequency * i) / sampleRate);
+  }
+  return samples;
+}
+
+function silenceFrame(): Float32Array {
+  return new Float32Array(FRAME_SIZE);
+}
+
+function noiseFrame(amplitude = 0.1): Float32Array {
+  const samples = new Float32Array(FRAME_SIZE);
+  for (let i = 0; i < FRAME_SIZE; i++) {
+    samples[i] = (Math.random() * 2 - 1) * amplitude;
+  }
+  return samples;
+}
+
+// ---------------------------------------------------------------------------
+// Output shape and finiteness
+// ---------------------------------------------------------------------------
+
+describe('MfccComputer.compute() — output shape', () => {
+  const mfcc = new MfccComputer();
+
+  it('returns exactly 13 coefficients', () => {
+    const result = mfcc.compute(sineFrame(440));
+    expect(result).toHaveLength(13);
+  });
+
+  it('all coefficients are finite numbers', () => {
+    const result = mfcc.compute(sineFrame(440));
+    result.forEach((c) => {
+      expect(typeof c).toBe('number');
+      expect(isFinite(c)).toBe(true);
+    });
+  });
+
+  it('returns finite coefficients for a silent (all-zero) frame', () => {
+    const result = mfcc.compute(silenceFrame());
+    expect(result).toHaveLength(13);
+    result.forEach((c) => expect(isFinite(c)).toBe(true));
+  });
+
+  it('returns finite coefficients for random noise', () => {
+    const result = mfcc.compute(noiseFrame());
+    result.forEach((c) => expect(isFinite(c)).toBe(true));
+  });
+
+  it('returns finite coefficients for a full-amplitude sine wave', () => {
+    const result = mfcc.compute(sineFrame(1000));
+    result.forEach((c) => expect(isFinite(c)).toBe(true));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+describe('MfccComputer.compute() — determinism', () => {
+  it('produces identical output on repeated calls with the same input', () => {
+    const mfcc = new MfccComputer();
+    const frame = sineFrame(440);
+    const first = mfcc.compute(frame);
+    const second = mfcc.compute(frame);
+    expect(first).toEqual(second);
+  });
+
+  it('two separate instances produce identical output for the same input', () => {
+    const a = new MfccComputer();
+    const b = new MfccComputer();
+    const frame = sineFrame(880);
+    expect(a.compute(frame)).toEqual(b.compute(frame));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Signal sensitivity — different inputs should produce different coefficients
+// ---------------------------------------------------------------------------
+
+describe('MfccComputer.compute() — signal sensitivity', () => {
+  const mfcc = new MfccComputer();
+
+  it('produces different coefficients for different frequencies', () => {
+    const low = mfcc.compute(sineFrame(500));
+    const high = mfcc.compute(sineFrame(4000));
+    // At least one coefficient differs between a 500 Hz and 4000 Hz tone
+    const anyDiffers = low.some((v, i) => Math.abs(v - high[i]) > 0.01);
+    expect(anyDiffers).toBe(true);
+  });
+
+  it('produces different coefficients for silence vs noise', () => {
+    const silent = mfcc.compute(silenceFrame());
+    const noisy = mfcc.compute(noiseFrame(0.5));
+    const anyDiffers = silent.some((v, i) => Math.abs(v - noisy[i]) > 0.01);
+    expect(anyDiffers).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partial frame (fewer than 400 samples)
+// ---------------------------------------------------------------------------
+
+describe('MfccComputer.compute() — partial frames', () => {
+  const mfcc = new MfccComputer();
+
+  it('handles a 200-sample (half-frame) input without throwing', () => {
+    const half = new Float32Array(200);
+    for (let i = 0; i < 200; i++) half[i] = Math.sin((2 * Math.PI * 440 * i) / 16000);
+    const result = mfcc.compute(half);
+    expect(result).toHaveLength(13);
+    result.forEach((c) => expect(isFinite(c)).toBe(true));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// frameLogEnergy
+// ---------------------------------------------------------------------------
+
+describe('frameLogEnergy()', () => {
+  it('returns a finite number for a sine wave', () => {
+    const energy = frameLogEnergy(sineFrame(440));
+    expect(typeof energy).toBe('number');
+    expect(isFinite(energy)).toBe(true);
+  });
+
+  it('returns a value ≤ 0 for normalised PCM (samples in [-1,1])', () => {
+    // RMS of a full-amplitude 0 dBFS signal is at most 0 dBFS
+    expect(frameLogEnergy(sineFrame(440))).toBeLessThanOrEqual(0.1); // small tolerance
+  });
+
+  it('returns a more negative value for silence than for noise', () => {
+    const silentEnergy = frameLogEnergy(silenceFrame());
+    const noisyEnergy = frameLogEnergy(noiseFrame(0.5));
+    expect(silentEnergy).toBeLessThan(noisyEnergy);
+  });
+
+  it('is clamped to -96 dBFS for a zero-amplitude frame', () => {
+    expect(frameLogEnergy(silenceFrame())).toBeGreaterThanOrEqual(-96);
+  });
+});

--- a/app.json
+++ b/app.json
@@ -19,13 +19,32 @@
         {
           "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone."
         }
+      ],
+      [
+        "@siteed/audio-studio",
+        {
+          "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone for speech transcription."
+        }
       ]
     ],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.lastbranch.soziaclient"
     },
     "android": {
-      "predictiveBackGestureEnabled": false
-    }
+      "package": "com.lastbranch.soziaclient",
+      "predictiveBackGestureEnabled": false,
+      "permissions": [
+        "android.permission.CAMERA",
+        "android.permission.RECORD_AUDIO",
+        "android.permission.MODIFY_AUDIO_SETTINGS"
+      ]
+    },
+    "extra": {
+      "eas": {
+        "projectId": "e1dc5c9f-dc85-4ddb-ac54-4445426a49e6"
+      }
+    },
+    "owner": "last-branch"
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,21 @@
+{
+  "cli": {
+    "version": ">= 18.7.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "dependencies": {
         "@mediapipe/tasks-vision": "^0.10.34",
+        "@siteed/audio-studio": "^3.0.3",
         "babel-preset-expo": "~54.0.10",
         "expo": "~54.0.33",
         "expo-audio": "~1.1.1",
         "expo-camera": "~17.0.10",
+        "expo-dev-client": "~6.0.20",
         "expo-status-bar": "~3.0.9",
         "lucide-react-native": "^0.577.0",
         "nativewind": "^4.2.3",
@@ -1770,6 +1772,129 @@
         "node-forge": "^1.3.3"
       }
     },
+    "node_modules/@expo/config": {
+      "version": "12.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.13.tgz",
+      "integrity": "sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "~54.0.4",
+        "@expo/config-types": "^54.0.10",
+        "@expo/json-file": "^10.0.8",
+        "deepmerge": "^4.3.1",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "resolve-workspace-root": "^2.0.0",
+        "semver": "^7.6.0",
+        "slugify": "^1.3.4",
+        "sucrase": "~3.35.1"
+      }
+    },
+    "node_modules/@expo/config-plugins": {
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.8.tgz",
+      "integrity": "sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "~10.0.13",
+        "@expo/plist": "^0.5.2",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@expo/config-types": {
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
+      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@expo/config/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/config/node_modules/@expo/config-plugins": {
+      "version": "54.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.4.tgz",
+      "integrity": "sha512-g2yXGICdoOw5i3LkQSDxl2Q5AlQCrG7oniu0pCPPO+UxGb7He4AFqSvPSy8HpRUj55io17hT62FTjYRD+d6j3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^54.0.10",
+        "@expo/json-file": "~10.0.8",
+        "@expo/plist": "^0.4.8",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slash": "^3.0.0",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/@expo/config/node_modules/@expo/config-types": {
+      "version": "54.0.10",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.10.tgz",
+      "integrity": "sha512-/J16SC2an1LdtCZ67xhSkGXpALYUVUNyZws7v+PVsFZxClYehDSoKLqyRaGkpHlYrCc08bS0RF5E0JV6g50psA==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/config/node_modules/@expo/plist": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
+      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/@expo/config/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@expo/devcert": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@expo/devcert/-/devcert-1.2.1.tgz",
@@ -1930,9 +2055,9 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "10.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.12.tgz",
-      "integrity": "sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==",
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.13.tgz",
+      "integrity": "sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -1996,75 +2121,6 @@
         "expo": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/@expo/config": {
-      "version": "12.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.13.tgz",
-      "integrity": "sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~54.0.4",
-        "@expo/config-types": "^54.0.10",
-        "@expo/json-file": "^10.0.8",
-        "deepmerge": "^4.3.1",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "require-from-string": "^2.0.2",
-        "resolve-from": "^5.0.0",
-        "resolve-workspace-root": "^2.0.0",
-        "semver": "^7.6.0",
-        "slugify": "^1.3.4",
-        "sucrase": "~3.35.1"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/@expo/config-plugins": {
-      "version": "54.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.4.tgz",
-      "integrity": "sha512-g2yXGICdoOw5i3LkQSDxl2Q5AlQCrG7oniu0pCPPO+UxGb7He4AFqSvPSy8HpRUj55io17hT62FTjYRD+d6j3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-types": "^54.0.10",
-        "@expo/json-file": "~10.0.8",
-        "@expo/plist": "^0.4.8",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.4",
-        "slash": "^3.0.0",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/@expo/config-types": {
-      "version": "54.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.10.tgz",
-      "integrity": "sha512-/J16SC2an1LdtCZ67xhSkGXpALYUVUNyZws7v+PVsFZxClYehDSoKLqyRaGkpHlYrCc08bS0RF5E0JV6g50psA==",
-      "license": "MIT"
-    },
-    "node_modules/@expo/metro-config/node_modules/@expo/config/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/@expo/plist": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
-      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^15.1.1"
       }
     },
     "node_modules/@expo/metro-config/node_modules/balanced-match": {
@@ -2140,18 +2196,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/@expo/metro-config/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/osascript": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.4.2.tgz",
@@ -2178,6 +2222,18 @@
         "resolve-workspace-root": "^2.0.0"
       }
     },
+    "node_modules/@expo/plist": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
+      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
     "node_modules/@expo/prebuild-config": {
       "version": "54.0.8",
       "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
@@ -2197,36 +2253,6 @@
       },
       "peerDependencies": {
         "expo": "*"
-      }
-    },
-    "node_modules/@expo/prebuild-config/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/@expo/prebuild-config/node_modules/@expo/config": {
-      "version": "12.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.13.tgz",
-      "integrity": "sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~54.0.4",
-        "@expo/config-types": "^54.0.10",
-        "@expo/json-file": "^10.0.8",
-        "deepmerge": "^4.3.1",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "require-from-string": "^2.0.2",
-        "resolve-from": "^5.0.0",
-        "resolve-workspace-root": "^2.0.0",
-        "semver": "^7.6.0",
-        "slugify": "^1.3.4",
-        "sucrase": "~3.35.1"
       }
     },
     "node_modules/@expo/prebuild-config/node_modules/@expo/config-plugins": {
@@ -3294,6 +3320,18 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@siteed/audio-studio": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@siteed/audio-studio/-/audio-studio-3.0.3.tgz",
+      "integrity": "sha512-hYoGC1D7ltzu6Dors7KaYBPrlLAX/q6iKclT4EmP+V9TEBcFiagEKxV2sVnA1XUFl6QCry9iyWgCKda+/BZGMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@expo/config-plugins": ">=7.0.0",
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@types/babel__core": {
@@ -5741,85 +5779,77 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-constants/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+    "node_modules/expo-dev-client": {
+      "version": "6.0.20",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-6.0.20.tgz",
+      "integrity": "sha512-5XjoVlj1OxakNxy55j/AUaGPrDOlQlB6XdHLLWAw61w5ffSpUDHDnuZzKzs9xY1eIaogOqTOQaAzZ2ddBkdXLA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.10.4"
+        "expo-dev-launcher": "6.0.20",
+        "expo-dev-menu": "7.0.18",
+        "expo-dev-menu-interface": "2.0.0",
+        "expo-manifests": "~1.0.10",
+        "expo-updates-interface": "~2.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
-    "node_modules/expo-constants/node_modules/@expo/config": {
-      "version": "12.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.13.tgz",
-      "integrity": "sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==",
+    "node_modules/expo-dev-launcher": {
+      "version": "6.0.20",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-6.0.20.tgz",
+      "integrity": "sha512-a04zHEeT9sB0L5EB38fz7sNnUKJ2Ar1pXpcyl60Ki8bXPNCs9rjY7NuYrDkP/irM8+1DklMBqHpyHiLyJ/R+EA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~54.0.4",
-        "@expo/config-types": "^54.0.10",
-        "@expo/json-file": "^10.0.8",
-        "deepmerge": "^4.3.1",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "require-from-string": "^2.0.2",
-        "resolve-from": "^5.0.0",
-        "resolve-workspace-root": "^2.0.0",
-        "semver": "^7.6.0",
-        "slugify": "^1.3.4",
-        "sucrase": "~3.35.1"
+        "ajv": "^8.11.0",
+        "expo-dev-menu": "7.0.18",
+        "expo-manifests": "~1.0.10"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
-    "node_modules/expo-constants/node_modules/@expo/config-plugins": {
-      "version": "54.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.4.tgz",
-      "integrity": "sha512-g2yXGICdoOw5i3LkQSDxl2Q5AlQCrG7oniu0pCPPO+UxGb7He4AFqSvPSy8HpRUj55io17hT62FTjYRD+d6j3Q==",
+    "node_modules/expo-dev-launcher/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-types": "^54.0.10",
-        "@expo/json-file": "~10.0.8",
-        "@expo/plist": "^0.4.8",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.4",
-        "slash": "^3.0.0",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/expo-constants/node_modules/@expo/config-types": {
-      "version": "54.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.10.tgz",
-      "integrity": "sha512-/J16SC2an1LdtCZ67xhSkGXpALYUVUNyZws7v+PVsFZxClYehDSoKLqyRaGkpHlYrCc08bS0RF5E0JV6g50psA==",
+    "node_modules/expo-dev-launcher/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
-    "node_modules/expo-constants/node_modules/@expo/plist": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
-      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
+    "node_modules/expo-dev-menu": {
+      "version": "7.0.18",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-7.0.18.tgz",
+      "integrity": "sha512-4kTdlHrnZCAWCT6tZRQHSSjZ7vECFisL4T+nsG/GJDo/jcHNaOVGV5qPV9wzlTxyMk3YOPggRw4+g7Ownrg5eA==",
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^15.1.1"
+        "expo-dev-menu-interface": "2.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
-    "node_modules/expo-constants/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+    "node_modules/expo-dev-menu-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-2.0.0.tgz",
+      "integrity": "sha512-BvAMPt6x+vyXpThsyjjOYyjwfjREV4OOpQkZ0tNl+nGpsPfcY9mc6DRACoWnH9KpLzyIt3BOgh3cuy/h/OxQjw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-file-system": {
@@ -5847,6 +5877,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-15.0.8.tgz",
@@ -5855,6 +5891,19 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.10.tgz",
+      "integrity": "sha512-oxDUnURPcL4ZsOBY6X1DGWGuoZgVAFzp6PISWV7lPP2J0r8u1/ucuChBgpK7u1eLGFp6sDIPwXyEUCkI386XSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.11",
+        "expo-json-utils": "~0.15.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -5908,13 +5957,13 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+    "node_modules/expo-updates-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
+      "integrity": "sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
@@ -6002,27 +6051,6 @@
         "react-native": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo/node_modules/@expo/config": {
-      "version": "12.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.13.tgz",
-      "integrity": "sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~54.0.4",
-        "@expo/config-types": "^54.0.10",
-        "@expo/json-file": "^10.0.8",
-        "deepmerge": "^4.3.1",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "require-from-string": "^2.0.2",
-        "resolve-from": "^5.0.0",
-        "resolve-workspace-root": "^2.0.0",
-        "semver": "^7.6.0",
-        "slugify": "^1.3.4",
-        "sucrase": "~3.35.1"
       }
     },
     "node_modules/expo/node_modules/@expo/config-plugins": {
@@ -6178,7 +6206,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -6221,6 +6248,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,12 @@
   },
   "dependencies": {
     "@mediapipe/tasks-vision": "^0.10.34",
+    "@siteed/audio-studio": "^3.0.3",
     "babel-preset-expo": "~54.0.10",
     "expo": "~54.0.33",
     "expo-audio": "~1.1.1",
     "expo-camera": "~17.0.10",
+    "expo-dev-client": "~6.0.20",
     "expo-status-bar": "~3.0.9",
     "lucide-react-native": "^0.577.0",
     "nativewind": "^4.2.3",

--- a/sozia/client/pipeline/audio/ExpoAudioPipeline.ts
+++ b/sozia/client/pipeline/audio/ExpoAudioPipeline.ts
@@ -1,70 +1,71 @@
-import {
-  AudioModule,
-  RecordingPresets,
-  setAudioModeAsync,
-  type AudioRecorder,
-  type RecordingOptions,
-} from 'expo-audio';
-import { Platform } from 'react-native';
+import { LegacyEventEmitter } from 'expo-modules-core';
+import { AudioStudioModule } from '@siteed/audio-studio';
 
 import type { PipelineHealth } from '@common/models';
 import type { TransmissionManager } from '@/transmission/TransmissionManager';
 import type { IAudioPipeline, MFCCFrame, RawAudioHandle } from './AudioPipeline';
 import { AudioChunker } from './AudioChunker';
+import { MfccComputer, frameLogEnergy } from './MfccComputer';
 import type { SensitivityLevel } from './VoiceActivityDetector';
 
-const FRAME_INTERVAL_MS = 25; // 40 Hz frame rate
-const NUM_MFCC_COEFFICIENTS = 13;
-const NOISE_FLOOR_DBFS = -60; // assumed noise floor for SNR estimation
+const SAMPLE_RATE = 16_000;
+const FRAME_INTERVAL_MS = 25; // 40 Hz → 400 samples per frame at 16 kHz
+const FRAME_SIZE_SAMPLES = (SAMPLE_RATE * FRAME_INTERVAL_MS) / 1000; // 400
+const NOISE_FLOOR_DBFS = -60;
 
-// Mirrors expo-audio@1.1.x internal `createRecordingOptions`. Revisit on upgrade.
-// See TP-CLIENT-AUDIO-007 for shape assertion.
-function flattenRecordingOptions(options: RecordingOptions): Record<string, unknown> {
-  const common = {
-    extension: options.extension,
-    sampleRate: options.sampleRate,
-    numberOfChannels: options.numberOfChannels,
-    bitRate: options.bitRate,
-    isMeteringEnabled: options.isMeteringEnabled ?? false,
-  };
-  if (Platform.OS === 'ios') return { ...common, ...options.ios };
-  if (Platform.OS === 'android') return { ...common, ...options.android };
-  return { ...common, ...options.web };
+/**
+ * Minimal interface covering the recording methods we call on the underlying
+ * audio module. On native the NativeModule satisfies this directly; on web we
+ * obtain the AudioStudioWeb singleton instance via the factory call.
+ */
+interface AudioRecorder {
+  startRecording(config: unknown): Promise<void>;
+  stopRecording?(): Promise<void>;
+  pauseRecording?(): Promise<void>;
+  resumeRecording?(): Promise<void>;
 }
 
 /**
- * Concrete implementation of IAudioPipeline for Expo (React Native) environments.
+ * Concrete implementation of IAudioPipeline using @siteed/audio-studio.
  *
- * Uses `expo-audio` for microphone capture. Owns an internal AudioChunker that
- * batches MFCC frames through VAD + feature extraction; completed chunks are
- * pushed directly to the TransmissionManager supplied at `start()` time,
- * matching LLD §3.2.3.
+ * PCM delivery differs by platform:
+ * - Web:    `AudioStudioWeb` emits `'AudioData'` events (via its own `LegacyEventEmitter`)
+ *           with `event.buffer: Float32Array`. Subscribed via `instance.addListener()`.
+ * - Native: `cleanNativeOptions` JSON-serialises the startRecording config before it
+ *           reaches the bridge, silently dropping all function fields including
+ *           `onAudioStream`. PCM is delivered instead via a `LegacyEventEmitter` wrapping
+ *           `AudioStudioModule`, emitting `'AudioData'` with `event.pcmFloat32`
+ *           (Android = `Float32Array`, iOS = `number[]`).
  *
- * MFCC extraction is a placeholder based on expo-audio's dBFS metering values;
- * it will be replaced with a proper Mel filterbank + DCT computation once raw
- * PCM sample buffers are accessible. See `_placeholderMfcc()` for details.
+ * `MfccComputer` performs pre-emphasis → Hamming window → FFT → Mel filterbank → log → DCT-II.
+ * Frames are sliced from a rolling sample accumulator so each MFCC frame always receives
+ * exactly FRAME_SIZE_SAMPLES samples regardless of how the native bridge chunks the data.
+ *
+ * Platform normalisation: `_resolveRecorder()` returns the object that carries
+ * `startRecording`/`stopRecording`/etc. On web this is the `AudioStudioWeb` singleton
+ * (obtained by calling the factory). On native it is `AudioStudioModule` directly.
  */
 export class ExpoAudioPipeline implements IAudioPipeline {
   private sessionId = '';
   private sessionStartMs = 0;
   private available = false;
   private paused = false;
+  private recordingActive = false;
   private lastUpdatedMs = 0;
   private currentSnr: number | null = null;
 
-  private recorder: AudioRecorder | null = null;
-  private frameTimer: ReturnType<typeof setInterval> | null = null;
+  private sampleAccumulator = new Float32Array(0);
   private frameListeners = new Set<(frame: MFCCFrame) => void>();
 
-  /** Most recent dBFS metering value polled from the recorder. */
-  private lastMeteringDbfs = NOISE_FLOOR_DBFS;
-
   private readonly chunker: AudioChunker;
+  private readonly mfcc: MfccComputer;
   private tx: TransmissionManager | null = null;
   private unsubscribeChunker: (() => void) | null = null;
+  private audioSubscription: { remove: () => void } | null = null;
 
   constructor(chunker: AudioChunker = new AudioChunker()) {
     this.chunker = chunker;
+    this.mfcc = new MfccComputer();
   }
 
   async start(
@@ -74,53 +75,87 @@ export class ExpoAudioPipeline implements IAudioPipeline {
   ): Promise<void> {
     if (this.available || this.paused) return;
 
-    await setAudioModeAsync({
-      allowsRecording: true,
-      playsInSilentMode: true,
-    });
-
-    const options = flattenRecordingOptions({
-      ...RecordingPresets.HIGH_QUALITY,
-      isMeteringEnabled: true,
-    });
-    const recorder = new AudioModule.AudioRecorder(options);
-    await recorder.prepareToRecordAsync();
-    recorder.record();
-
-    this.recorder = recorder;
     this.sessionId = sessionId;
     this.sessionStartMs = Date.now();
     this.available = true;
     this.paused = false;
     this.tx = tx ?? null;
+    this.sampleAccumulator = new Float32Array(0);
 
     this.chunker.start(sessionId);
     this.unsubscribeChunker = this.chunker.onChunk((chunk) => {
       this.tx?.sendFeatures(chunk);
     });
 
-    this._startFrameTimer();
+    const recorder = this._resolveRecorder();
+    this.recordingActive = true;
+
+    const isWeb =
+      typeof AudioStudioModule === 'function' && !('startRecording' in AudioStudioModule);
+
+    const recordingConfig = {
+      sampleRate: SAMPLE_RATE,
+      channels: 1,
+      encoding: 'pcm_16bit',
+      streamFormat: 'float32',
+      interval: FRAME_INTERVAL_MS,
+      output: { primary: { enabled: false } },
+    };
+
+    if (isWeb) {
+      // On web, AudioStudioWeb emits 'AudioData' events via its own LegacyEventEmitter.
+      // The onAudioStream config field is native-only and never called on web.
+      type WebInstance = { addListener: (event: string, cb: (e: { buffer: Float32Array }) => void) => { remove: () => void } };
+      this.audioSubscription = (recorder as unknown as WebInstance).addListener(
+        'AudioData',
+        (event) => {
+          if (!this.available || this.paused) return;
+          this._processBuffer(event.buffer);
+        },
+      );
+    } else {
+      // On native, startRecording config is JSON-serialised by cleanNativeOptions before reaching
+      // the bridge — all function fields (including onAudioStream) are silently stripped.
+      // PCM data is delivered via a LegacyEventEmitter 'AudioData' event instead.
+      type NativeAudioEvent = { pcmFloat32?: Float32Array | number[]; buffer?: Float32Array };
+      const emitter = new LegacyEventEmitter(AudioStudioModule as never);
+      this.audioSubscription = emitter.addListener('AudioData', (event: NativeAudioEvent) => {
+        if (!this.available || this.paused) return;
+        const raw = event.pcmFloat32 ?? event.buffer;
+        if (!raw || raw.length === 0) return;
+        const samples = raw instanceof Float32Array ? raw : new Float32Array(raw);
+        this._processBuffer(samples);
+      });
+    }
+
+    await recorder.startRecording(recordingConfig);
   }
 
   pause(): void {
     if (!this.available || this.paused) return;
     this.paused = true;
     this.available = false;
-    this._stopFrameTimer();
-    this.recorder?.pause();
+    if (this.recordingActive) {
+      this._resolveRecorder().pauseRecording?.().catch((err: unknown) => {
+        console.warn('[ExpoAudioPipeline] pauseRecording failed:', err);
+      });
+    }
   }
 
   resume(): void {
     if (!this.paused) return;
     this.paused = false;
     this.available = true;
-    // expo-audio: record() also resumes a paused recorder.
-    this.recorder?.record();
-    this._startFrameTimer();
+    if (this.recordingActive) {
+      this._resolveRecorder().resumeRecording?.().catch((err: unknown) => {
+        console.warn('[ExpoAudioPipeline] resumeRecording failed:', err);
+      });
+    }
   }
 
   stop(): void {
-    this._stopFrameTimer();
+    this.audioSubscription?.remove();
+    this.audioSubscription = null;
     this.frameListeners.clear();
     this.unsubscribeChunker?.();
     this.unsubscribeChunker = null;
@@ -130,15 +165,14 @@ export class ExpoAudioPipeline implements IAudioPipeline {
     this.paused = false;
     this.sessionId = '';
     this.currentSnr = null;
+    this.sampleAccumulator = new Float32Array(0);
 
-    const rec = this.recorder;
-    this.recorder = null;
-    rec
-      ?.stop()
-      .then(() => setAudioModeAsync({ allowsRecording: false }))
-      .catch((err: unknown) => {
-        console.warn('[ExpoAudioPipeline] stop cleanup failed:', err);
+    if (this.recordingActive) {
+      this.recordingActive = false;
+      this._resolveRecorder().stopRecording?.().catch((err: unknown) => {
+        console.warn('[ExpoAudioPipeline] stopRecording failed:', err);
       });
+    }
   }
 
   getHealth(): PipelineHealth {
@@ -166,54 +200,51 @@ export class ExpoAudioPipeline implements IAudioPipeline {
   // Private helpers
   // ---------------------------------------------------------------------------
 
-  private _startFrameTimer(): void {
-    this.frameTimer = setInterval(() => {
-      if (this.recorder) {
-        const status = this.recorder.getStatus();
-        if (typeof status.metering === 'number') {
-          this.lastMeteringDbfs = status.metering;
-        }
-      }
-      const frame = this._extractFrame();
-      this.lastUpdatedMs = frame.timestampMs;
-      this.currentSnr = Math.max(0, this.lastMeteringDbfs - NOISE_FLOOR_DBFS);
-      this.chunker.push(frame);
-      this.frameListeners.forEach((cb) => cb(frame));
-    }, FRAME_INTERVAL_MS);
-  }
-
-  private _stopFrameTimer(): void {
-    if (this.frameTimer !== null) {
-      clearInterval(this.frameTimer);
-      this.frameTimer = null;
+  /**
+   * Returns the object that exposes `startRecording`, `stopRecording`, etc.
+   *
+   * On native: `AudioStudioModule` IS that object (NativeModule).
+   * On web:    `AudioStudioModule` is a factory function — invoking it (with no
+   *            arguments) returns the `AudioStudioWeb` singleton, which carries
+   *            all recording methods as instance methods.
+   */
+  private _resolveRecorder(): AudioRecorder {
+    if (typeof AudioStudioModule === 'function' && !('startRecording' in AudioStudioModule)) {
+      return (AudioStudioModule as unknown as (opts: Record<string, never>) => AudioRecorder)({} as Record<string, never>);
     }
-  }
-
-  private _extractFrame(): MFCCFrame {
-    const timestampMs = Date.now() - this.sessionStartMs;
-    const energy = this.lastMeteringDbfs;
-    const linearEnergy = Math.pow(10, energy / 20);
-    return {
-      timestampMs,
-      energy,
-      coefficients: this._placeholderMfcc(linearEnergy),
-    };
+    return AudioStudioModule as unknown as AudioRecorder;
   }
 
   /**
-   * Produces 13 synthetic MFCC coefficients from the current linear energy level
-   * via a deterministic cosine transform of a flat log-Mel spectrum.
-   *
-   * PLACEHOLDER — must be replaced with a proper Mel filterbank + DCT pipeline
-   * once raw PCM sample buffers are accessible. The output satisfies the
-   * MFCCFrame contract (13 finite floats) and enables full pipeline wiring
-   * and device-level testing without PCM access.
+   * Append incoming PCM samples to the rolling accumulator and emit one MFCC
+   * frame for every FRAME_SIZE_SAMPLES available. Any leftover samples are
+   * retained for the next callback invocation.
    */
-  private _placeholderMfcc(linearEnergy: number): number[] {
-    const logEnergy = Math.log(linearEnergy + 1e-10);
-    return Array.from(
-      { length: NUM_MFCC_COEFFICIENTS },
-      (_, k) => logEnergy * Math.cos((Math.PI / NUM_MFCC_COEFFICIENTS) * (k + 0.5))
-    );
+  private _processBuffer(incoming: Float32Array): void {
+    const prev = this.sampleAccumulator;
+    const combined = new Float32Array(prev.length + incoming.length);
+    combined.set(prev);
+    combined.set(incoming, prev.length);
+
+    let offset = 0;
+    while (offset + FRAME_SIZE_SAMPLES <= combined.length) {
+      const frameSamples = combined.subarray(offset, offset + FRAME_SIZE_SAMPLES);
+      this._emitFrame(frameSamples);
+      offset += FRAME_SIZE_SAMPLES;
+    }
+
+    this.sampleAccumulator = combined.slice(offset);
+  }
+
+  private _emitFrame(samples: Float32Array): void {
+    const timestampMs = Date.now() - this.sessionStartMs;
+    const coefficients = this.mfcc.compute(samples);
+    const energy = frameLogEnergy(samples);
+    const frame: MFCCFrame = { timestampMs, coefficients, energy };
+
+    this.lastUpdatedMs = timestampMs;
+    this.currentSnr = Math.max(0, energy - NOISE_FLOOR_DBFS);
+    this.chunker.push(frame);
+    this.frameListeners.forEach((cb) => cb(frame));
   }
 }

--- a/sozia/client/pipeline/audio/MfccComputer.ts
+++ b/sozia/client/pipeline/audio/MfccComputer.ts
@@ -1,0 +1,251 @@
+/**
+ * Pure-JS MFCC computation.
+ *
+ * Pipeline per frame:
+ *   pre-emphasis → Hamming window → zero-pad to FFT size →
+ *   FFT → power spectrum → Mel filterbank → log → DCT → first 13 coefficients
+ *
+ * Designed to operate on exactly FRAME_SIZE_SAMPLES (400) samples of Float32
+ * PCM in the [-1, 1] range, as produced by @siteed/expo-audio-studio with
+ * streamFormat: 'float32' at 16 kHz mono.
+ */
+
+const SAMPLE_RATE = 16_000; // Hz
+const FRAME_SIZE_SAMPLES = 400; // 25 ms at 16 kHz
+const FFT_SIZE = 512; // next power-of-2 above FRAME_SIZE_SAMPLES
+const NUM_MEL_FILTERS = 26;
+const NUM_MFCC_COEFFICIENTS = 13;
+const PRE_EMPHASIS = 0.97;
+const MEL_LOW_HZ = 80;
+const MEL_HIGH_HZ = 8_000;
+
+// ---------------------------------------------------------------------------
+// Hz ↔ Mel conversions (O'Shaughnessy formula)
+// ---------------------------------------------------------------------------
+
+function hzToMel(hz: number): number {
+  return 2595 * Math.log10(1 + hz / 700);
+}
+
+function melToHz(mel: number): number {
+  return 700 * (Math.pow(10, mel / 2595) - 1);
+}
+
+// ---------------------------------------------------------------------------
+// Hamming window (pre-computed once per MfccComputer instance)
+// ---------------------------------------------------------------------------
+
+function buildHammingWindow(N: number): Float32Array {
+  const w = new Float32Array(N);
+  for (let n = 0; n < N; n++) {
+    w[n] = 0.54 - 0.46 * Math.cos((2 * Math.PI * n) / (N - 1));
+  }
+  return w;
+}
+
+// ---------------------------------------------------------------------------
+// Mel filterbank — returns NUM_MEL_FILTERS × (FFT_SIZE/2+1) weight matrix,
+// stored row-major as a single Float32Array for cache efficiency.
+// ---------------------------------------------------------------------------
+
+function buildMelFilterbank(
+  numFilters: number,
+  fftSize: number,
+  sampleRate: number,
+  lowHz: number,
+  highHz: number,
+): Float32Array {
+  const numBins = fftSize / 2 + 1;
+  const bank = new Float32Array(numFilters * numBins);
+
+  const lowMel = hzToMel(lowHz);
+  const highMel = hzToMel(highHz);
+
+  // numFilters + 2 centre points equally spaced in Mel
+  const melPoints = new Float32Array(numFilters + 2);
+  for (let i = 0; i < numFilters + 2; i++) {
+    melPoints[i] = lowMel + (i * (highMel - lowMel)) / (numFilters + 1);
+  }
+
+  // Convert centre points to FFT bin indices
+  const binPoints = new Float32Array(numFilters + 2);
+  for (let i = 0; i < numFilters + 2; i++) {
+    binPoints[i] = Math.floor(((fftSize + 1) * melToHz(melPoints[i])) / sampleRate);
+  }
+
+  for (let m = 0; m < numFilters; m++) {
+    const left = binPoints[m];
+    const centre = binPoints[m + 1];
+    const right = binPoints[m + 2];
+    const row = m * numBins;
+
+    for (let k = left; k < centre; k++) {
+      bank[row + k] = (k - left) / (centre - left);
+    }
+    for (let k = centre; k <= right; k++) {
+      bank[row + k] = (right - k) / (right - centre);
+    }
+  }
+
+  return bank;
+}
+
+// ---------------------------------------------------------------------------
+// In-place Cooley-Tukey FFT (power-of-2 size, real input)
+// ---------------------------------------------------------------------------
+
+function fftInPlace(real: Float32Array, imag: Float32Array): void {
+  const N = real.length;
+
+  // Bit-reversal permutation
+  for (let i = 1, j = 0; i < N; i++) {
+    let bit = N >> 1;
+    for (; j & bit; bit >>= 1) j ^= bit;
+    j ^= bit;
+    if (i < j) {
+      let tmp = real[i];
+      real[i] = real[j];
+      real[j] = tmp;
+      tmp = imag[i];
+      imag[i] = imag[j];
+      imag[j] = tmp;
+    }
+  }
+
+  // Butterfly passes
+  for (let len = 2; len <= N; len <<= 1) {
+    const ang = (2 * Math.PI) / len;
+    const wReal = Math.cos(ang);
+    const wImag = -Math.sin(ang);
+
+    for (let i = 0; i < N; i += len) {
+      let tReal = 1.0;
+      let tImag = 0.0;
+
+      for (let j = 0; j < len >> 1; j++) {
+        const uR = real[i + j];
+        const uI = imag[i + j];
+        const vR = real[i + j + (len >> 1)] * tReal - imag[i + j + (len >> 1)] * tImag;
+        const vI = real[i + j + (len >> 1)] * tImag + imag[i + j + (len >> 1)] * tReal;
+
+        real[i + j] = uR + vR;
+        imag[i + j] = uI + vI;
+        real[i + j + (len >> 1)] = uR - vR;
+        imag[i + j + (len >> 1)] = uI - vI;
+
+        const nextR = tReal * wReal - tImag * wImag;
+        tImag = tReal * wImag + tImag * wReal;
+        tReal = nextR;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DCT-II — maps NUM_MEL_FILTERS log-Mel energies to NUM_MFCC_COEFFICIENTS
+// ---------------------------------------------------------------------------
+
+function dctCoefficients(logMel: Float32Array, numCoeffs: number): number[] {
+  const N = logMel.length;
+  const coeffs: number[] = new Array(numCoeffs);
+  for (let k = 0; k < numCoeffs; k++) {
+    let sum = 0;
+    for (let n = 0; n < N; n++) {
+      sum += logMel[n] * Math.cos((Math.PI / N) * (n + 0.5) * k);
+    }
+    coeffs[k] = sum;
+  }
+  return coeffs;
+}
+
+// ---------------------------------------------------------------------------
+// MfccComputer — stateless computation with pre-built, reusable buffers
+// ---------------------------------------------------------------------------
+
+export class MfccComputer {
+  private readonly hammingWindow: Float32Array;
+  private readonly melBank: Float32Array;
+
+  // Reusable work buffers (avoids GC pressure at 40 Hz)
+  private readonly fftReal: Float32Array;
+  private readonly fftImag: Float32Array;
+  private readonly melEnergies: Float32Array;
+
+  constructor() {
+    this.hammingWindow = buildHammingWindow(FRAME_SIZE_SAMPLES);
+    this.melBank = buildMelFilterbank(
+      NUM_MEL_FILTERS,
+      FFT_SIZE,
+      SAMPLE_RATE,
+      MEL_LOW_HZ,
+      MEL_HIGH_HZ,
+    );
+    this.fftReal = new Float32Array(FFT_SIZE);
+    this.fftImag = new Float32Array(FFT_SIZE);
+    this.melEnergies = new Float32Array(NUM_MEL_FILTERS);
+  }
+
+  /**
+   * Compute 13 MFCC coefficients from a single audio frame.
+   *
+   * @param samples - Exactly FRAME_SIZE_SAMPLES (400) Float32 PCM values in [-1, 1].
+   *   If fewer samples are provided the remainder is treated as zero-padded silence.
+   */
+  compute(samples: Float32Array): number[] {
+    // 1. Pre-emphasis
+    this.fftReal[0] = samples[0];
+    const len = Math.min(samples.length, FRAME_SIZE_SAMPLES);
+    for (let i = 1; i < len; i++) {
+      this.fftReal[i] = samples[i] - PRE_EMPHASIS * samples[i - 1];
+    }
+    // Zero-pad beyond FRAME_SIZE_SAMPLES
+    for (let i = len; i < FFT_SIZE; i++) {
+      this.fftReal[i] = 0;
+    }
+
+    // 2. Apply Hamming window (only over the live samples)
+    for (let i = 0; i < len; i++) {
+      this.fftReal[i] *= this.hammingWindow[i];
+    }
+
+    // 3. FFT (imaginary part starts as zero)
+    this.fftImag.fill(0);
+    fftInPlace(this.fftReal, this.fftImag);
+
+    // 4. Power spectrum (first FFT_SIZE/2+1 bins)
+    const numBins = FFT_SIZE / 2 + 1;
+
+    // 5. Mel filterbank
+    const numFilters = NUM_MEL_FILTERS;
+    for (let m = 0; m < numFilters; m++) {
+      let energy = 0;
+      const rowOffset = m * numBins;
+      for (let k = 0; k < numBins; k++) {
+        const power = this.fftReal[k] * this.fftReal[k] + this.fftImag[k] * this.fftImag[k];
+        energy += this.melBank[rowOffset + k] * power;
+      }
+      this.melEnergies[m] = energy;
+    }
+
+    // 6. Log (with floor to avoid log(0))
+    for (let m = 0; m < numFilters; m++) {
+      this.melEnergies[m] = Math.log(this.melEnergies[m] + 1e-10);
+    }
+
+    // 7. DCT → first 13 coefficients
+    return dctCoefficients(this.melEnergies, NUM_MFCC_COEFFICIENTS);
+  }
+}
+
+/**
+ * Compute the log-energy of a frame in dBFS.
+ * Returns a value in (-∞, 0], clamped to −96 dBFS for silence.
+ */
+export function frameLogEnergy(samples: Float32Array): number {
+  let sumSq = 0;
+  for (let i = 0; i < samples.length; i++) {
+    sumSq += samples[i] * samples[i];
+  }
+  const rms = Math.sqrt(sumSq / samples.length);
+  return Math.max(20 * Math.log10(rms + 1e-9), -96);
+}

--- a/sozia/client/pipeline/audio/index.ts
+++ b/sozia/client/pipeline/audio/index.ts
@@ -1,5 +1,6 @@
 export type { IAudioPipeline, MFCCFrame, RawAudioHandle } from './AudioPipeline';
 export { ExpoAudioPipeline } from './ExpoAudioPipeline';
+export { MfccComputer, frameLogEnergy } from './MfccComputer';
 export { AudioChunker } from './AudioChunker';
 export { VoiceActivityDetector } from './VoiceActivityDetector';
 export type { SensitivityLevel } from './VoiceActivityDetector';

--- a/sozia/client/ui/screens/LiveTranslationScreen.tsx
+++ b/sozia/client/ui/screens/LiveTranslationScreen.tsx
@@ -62,7 +62,7 @@ export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
           {/* Top bar */}
           <View className="z-20 flex-row items-center justify-between bg-black/30 px-6 pt-3 pb-2">
             <Text className="text-xs font-semibold text-white">Sozia · {state}</Text>
-            <TouchableOpacity onPress={onBack}>
+            <TouchableOpacity onPress={() => { stopSession(); onBack(); }}>
               <Text className="text-xs font-semibold text-gray-300">{t('live.back')}</Text>
             </TouchableOpacity>
           </View>
@@ -71,7 +71,7 @@ export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
 
           <View className="relative flex-1">
             {/* Camera background */}
-            <View ref={cameraContainerRef} className="absolute inset-0 items-center justify-center bg-gray-800">
+            <View ref={cameraContainerRef} className="absolute inset-0 items-center justify-center bg-gray-800" pointerEvents="none">
               {shouldShowLiveCamera ? (
                 <>
                   <CameraView


### PR DESCRIPTION
## What does this PR do?

Replace the placeholder audio metering logic with a proper signal processing pipeline. This migrates the client from `expo-audio` to `@siteed/audio-studio` to access raw PCM streams, enabling the computation of Mel-frequency cepstral coefficients (MFCC) via a new pure-JS `MfccComputer`.

- Implement pre-emphasis, Hamming windowing, FFT, and Mel filterbank processing
- Add a rolling sample accumulator to ensure consistent 25ms frame windowing
- Support platform-specific PCM delivery for both Web and Native environments
- Ensure audio sessions are properly terminated when navigating away from the translation screen

Configure EAS build profiles, update package identifiers, and integrate expo-dev-client. This transition from Expo Go is required to support custom native modules like @siteed/audio-studio for speech transcription and advanced audio settings.

## Which package(s) does it touch?

- sozia.client.pipeline.audio

## How to test

- `npm run check`

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally