### PR TITLE
fix(ui): start video pipeline in SPEECH mode for lip-reading

### DIFF
--- a/sozia/client/ui/controller/SessionController.tsx
+++ b/sozia/client/ui/controller/SessionController.tsx
@@ -182,13 +182,15 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
         () => { actions.onConnectionLost(); },
       );
 
+      const videoEl = cameraVideoRef.current;
+      const cameraHandle = videoEl
+        ? { getFrame: () => ({ timestampMs: Date.now(), width: videoEl.videoWidth, height: videoEl.videoHeight, data: videoEl }) }
+        : {};
+
       if (path === ModalityPath.SPEECH) {
         await deviceManager.current.startAudioPipeline(newSessionId, {}, transmissionManager.current);
+        await deviceManager.current.startVideoPipeline(newSessionId, cameraHandle, transmissionManager.current);
       } else if (path === ModalityPath.SIGN) {
-        const videoEl = cameraVideoRef.current;
-        const cameraHandle = videoEl
-          ? { getFrame: () => ({ timestampMs: Date.now(), width: videoEl.videoWidth, height: videoEl.videoHeight, data: videoEl }) }
-          : {};
         await deviceManager.current.startVideoPipeline(newSessionId, cameraHandle, transmissionManager.current);
       }
 
@@ -245,10 +247,8 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
     };
   }, [state, activePath, actions]);
 
-  // Poll video pipeline health every second while a SIGN session is active.
-  // Transitions RUNNING → DEGRADED if tracking becomes unavailable.
   useEffect(() => {
-    if (activePath !== ModalityPath.SIGN) return;
+    if (!activePath) return;
     if (state !== SessionState.RUNNING && state !== SessionState.DEGRADED) return;
 
     let mounted = true;


### PR DESCRIPTION
## What does this PR do?

SPEECH sessions weren't starting the video pipeline at all — only the audio pipeline was running. That meant no landmark frames were being sent to the server, so lip-reading fusion couldn't kick in. Now startVideoPipeline is called for SPEECH sessions too, and video health polling runs in both modes.

## Which package(s) does it touch?

- `sozia.client.ui` (SessionController)

## How to test

1. Start a SPEECH session
2. Verify that TransmissionManager receives both audio chunks and landmark frames
3. Check that video health reports show up in StatusBar

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [ ] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [ ] Tested locally