### PR TITLE
fix(transmission): align wire format with server snake_case convention

### DIFF
--- a/__tests__/transmission/FeatureSerializer.test.ts
+++ b/__tests__/transmission/FeatureSerializer.test.ts
@@ -93,38 +93,38 @@ describe('FeatureSerializer', () => {
       expect(result.type).toBe('pipeline_health');
     });
 
-    it('preserves all LandmarkFrame fields', () => {
+    it('preserves all LandmarkFrame fields as snake_case', () => {
       const frame = makeLandmarkFrame();
       const result = JSON.parse(serializer.serialize(frame));
-      expect(result.sessionId).toBe(frame.sessionId);
-      expect(result.timestampMs).toBe(frame.timestampMs);
-      expect(result.faceLandmarks).toEqual(frame.faceLandmarks);
-      expect(result.leftHandLandmarks).toBeNull();
-      expect(result.rightHandLandmarks).toEqual(frame.rightHandLandmarks);
-      expect(result.poseLandmarks).toBeNull();
+      expect(result.session_id).toBe(frame.sessionId);
+      expect(result.timestamp_ms).toBe(frame.timestampMs);
+      expect(result.face_landmarks).toEqual(frame.faceLandmarks);
+      expect(result.left_hand_landmarks).toBeNull();
+      expect(result.right_hand_landmarks).toEqual(frame.rightHandLandmarks);
+      expect(result.pose_landmarks).toBeNull();
     });
 
-    it('preserves all AudioFeatureChunk fields', () => {
+    it('preserves all AudioFeatureChunk fields as snake_case', () => {
       const chunk = makeAudioChunk();
       const result = JSON.parse(serializer.serialize(chunk));
-      expect(result.sessionId).toBe(chunk.sessionId);
-      expect(result.timestampMs).toBe(chunk.timestampMs);
+      expect(result.session_id).toBe(chunk.sessionId);
+      expect(result.timestamp_ms).toBe(chunk.timestampMs);
       expect(result.features).toEqual(chunk.features);
-      expect(result.featureType).toBe(chunk.featureType);
-      expect(result.sampleRateHz).toBe(chunk.sampleRateHz);
-      expect(result.chunkDurationMs).toBe(chunk.chunkDurationMs);
+      expect(result.feature_type).toBe(chunk.featureType);
+      expect(result.sample_rate_hz).toBe(chunk.sampleRateHz);
+      expect(result.chunk_duration_ms).toBe(chunk.chunkDurationMs);
     });
 
-    it('preserves all PipelineHealth fields', () => {
+    it('preserves all PipelineHealth fields as snake_case', () => {
       const health = makePipelineHealth();
       const result = JSON.parse(serializer.serialize(health));
-      expect(result.sessionId).toBe(health.sessionId);
+      expect(result.session_id).toBe(health.sessionId);
       expect(result.pipeline).toBe(health.pipeline);
       expect(result.available).toBe(health.available);
       expect(result.fps).toBeNull();
       expect(result.snr).toBe(health.snr);
-      expect(result.faceDetected).toBeNull();
-      expect(result.lastUpdatedMs).toBe(health.lastUpdatedMs);
+      expect(result.face_detected).toBeNull();
+      expect(result.last_updated_ms).toBe(health.lastUpdatedMs);
     });
 
     it('correctly identifies PipelineHealth over LandmarkFrame when faceLandmarks is absent', () => {
@@ -142,19 +142,19 @@ describe('FeatureSerializer', () => {
       expect(result.type).toBe('session_init');
     });
 
-    it('includes sessionId', () => {
+    it('includes session_id', () => {
       const result = JSON.parse(serializer.sessionInit('session-abc', ModalityPath.SPEECH, ''));
-      expect(result.sessionId).toBe('session-abc');
+      expect(result.session_id).toBe('session-abc');
     });
 
-    it('includes activePath for SPEECH', () => {
+    it('includes modality_path for SPEECH', () => {
       const result = JSON.parse(serializer.sessionInit('s', ModalityPath.SPEECH, ''));
-      expect(result.activePath).toBe(ModalityPath.SPEECH);
+      expect(result.modality_path).toBe(ModalityPath.SPEECH);
     });
 
-    it('includes activePath for SIGN', () => {
+    it('includes modality_path for SIGN', () => {
       const result = JSON.parse(serializer.sessionInit('s', ModalityPath.SIGN, ''));
-      expect(result.activePath).toBe(ModalityPath.SIGN);
+      expect(result.modality_path).toBe(ModalityPath.SIGN);
     });
 
     it('includes api_key in the payload', () => {
@@ -176,9 +176,9 @@ describe('FeatureSerializer', () => {
       expect(result.type).toBe('session_end');
     });
 
-    it('includes sessionId', () => {
+    it('includes session_id', () => {
       const result = JSON.parse(serializer.sessionEnd('session-xyz'));
-      expect(result.sessionId).toBe('session-xyz');
+      expect(result.session_id).toBe('session-xyz');
     });
   });
 });

--- a/__tests__/transmission/SegmentReceiver.test.ts
+++ b/__tests__/transmission/SegmentReceiver.test.ts
@@ -22,16 +22,16 @@ import type { TranscriptSegment } from '@common/models';
 function validPayload(overrides: Record<string, unknown> = {}): string {
   return JSON.stringify({
     type: 'transcript_segment',
-    segmentId: 'seg-1',
-    sessionId: 'session-1',
+    segment_id: 'seg-1',
+    session_id: 'session-1',
     status: SegmentStatus.FINAL,
     text: 'Merhaba',
     source: ModalityType.ASR,
     confidence: 0.9,
-    timestampMs: 1000,
-    durationMs: 500,
-    createdAtMs: 1_700_000_000_000,
-    replacesSegmentId: null,
+    timestamp_ms: 1000,
+    duration_ms: 500,
+    created_at_ms: 1_700_000_000_000,
+    replaces_segment_id: null,
     ...overrides,
   });
 }
@@ -74,7 +74,7 @@ describe('SegmentReceiver', () => {
 
   it('accepts a non-null replacesSegmentId for PARTIAL→FINAL revision', () => {
     const result = receiver.deserialize(
-      validPayload({ replacesSegmentId: 'seg-0', status: SegmentStatus.FINAL }),
+      validPayload({ replaces_segment_id: 'seg-0', status: SegmentStatus.FINAL }),
     ) as TranscriptSegment;
     expect(result.replacesSegmentId).toBe('seg-0');
   });
@@ -100,12 +100,12 @@ describe('SegmentReceiver', () => {
 
   // -- missing required fields -----------------------------------------------
 
-  it('returns null when segmentId is missing', () => {
-    expect(receiver.deserialize(validPayload({ segmentId: undefined }))).toBeNull();
+  it('returns null when segment_id is missing', () => {
+    expect(receiver.deserialize(validPayload({ segment_id: undefined }))).toBeNull();
   });
 
-  it('returns null when sessionId is missing', () => {
-    expect(receiver.deserialize(validPayload({ sessionId: undefined }))).toBeNull();
+  it('returns null when session_id is missing', () => {
+    expect(receiver.deserialize(validPayload({ session_id: undefined }))).toBeNull();
   });
 
   it('returns null when status is missing', () => {
@@ -124,21 +124,21 @@ describe('SegmentReceiver', () => {
     expect(receiver.deserialize(validPayload({ confidence: undefined }))).toBeNull();
   });
 
-  it('returns null when timestampMs is missing', () => {
-    expect(receiver.deserialize(validPayload({ timestampMs: undefined }))).toBeNull();
+  it('returns null when timestamp_ms is missing', () => {
+    expect(receiver.deserialize(validPayload({ timestamp_ms: undefined }))).toBeNull();
   });
 
-  it('returns null when durationMs is missing', () => {
-    expect(receiver.deserialize(validPayload({ durationMs: undefined }))).toBeNull();
+  it('returns null when duration_ms is missing', () => {
+    expect(receiver.deserialize(validPayload({ duration_ms: undefined }))).toBeNull();
   });
 
-  it('returns null when createdAtMs is missing', () => {
-    expect(receiver.deserialize(validPayload({ createdAtMs: undefined }))).toBeNull();
+  it('returns null when created_at_ms is missing', () => {
+    expect(receiver.deserialize(validPayload({ created_at_ms: undefined }))).toBeNull();
   });
 
-  it('returns null when replacesSegmentId key is absent entirely', () => {
+  it('returns null when replaces_segment_id key is absent entirely', () => {
     const payload = JSON.parse(validPayload());
-    delete payload.replacesSegmentId;
+    delete payload.replaces_segment_id;
     expect(receiver.deserialize(JSON.stringify(payload))).toBeNull();
   });
 

--- a/__tests__/transmission/TransmissionManager.test.ts
+++ b/__tests__/transmission/TransmissionManager.test.ts
@@ -166,7 +166,7 @@ describe('TransmissionManager', () => {
       await expect(promise).resolves.toBeUndefined();
     });
 
-    it('sends session_init with sessionId, activePath, and api_key on open', async () => {
+    it('sends session_init with session_id, modality_path, and api_key on open', async () => {
       const { manager } = makeManager();
       const promise = manager.connect('session-1', ModalityPath.SIGN, 'test-key');
       const ws = FakeWebSocket.lastInstance!;
@@ -174,8 +174,8 @@ describe('TransmissionManager', () => {
 
       const msg = JSON.parse(ws.sentMessages[0]);
       expect(msg.type).toBe('session_init');
-      expect(msg.sessionId).toBe('session-1');
-      expect(msg.activePath).toBe(ModalityPath.SIGN);
+      expect(msg.session_id).toBe('session-1');
+      expect(msg.modality_path).toBe(ModalityPath.SIGN);
       expect(msg.api_key).toBe('test-key');
 
       ws.simulateReady();
@@ -237,7 +237,7 @@ describe('TransmissionManager', () => {
 
       const msg = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]);
       expect(msg.type).toBe('audio_feature_chunk');
-      expect(msg.timestampMs).toBe(100);
+      expect(msg.timestamp_ms).toBe(100);
     });
 
     it('sends landmark_frame immediately when connected', async () => {
@@ -248,7 +248,7 @@ describe('TransmissionManager', () => {
 
       const msg = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]);
       expect(msg.type).toBe('landmark_frame');
-      expect(msg.timestampMs).toBe(200);
+      expect(msg.timestamp_ms).toBe(200);
     });
 
     it('buffers features when not yet connected (socket CONNECTING)', () => {
@@ -281,7 +281,7 @@ describe('TransmissionManager', () => {
       expect(ws.sentMessages).toHaveLength(2);
       const flushed = JSON.parse(ws.sentMessages[1]);
       expect(flushed.type).toBe('audio_feature_chunk');
-      expect(flushed.timestampMs).toBe(42);
+      expect(flushed.timestamp_ms).toBe(42);
     });
 
     it('drops the oldest entry when buffer exceeds 200 items', async () => {
@@ -301,8 +301,8 @@ describe('TransmissionManager', () => {
       // session_init (1) + 200 buffered chunks (chunk 0 dropped)
       const buffered = ws.sentMessages.slice(1);
       expect(buffered).toHaveLength(200);
-      expect(JSON.parse(buffered[0]).timestampMs).toBe(1); // chunk 0 dropped
-      expect(JSON.parse(buffered[199]).timestampMs).toBe(200);
+      expect(JSON.parse(buffered[0]).timestamp_ms).toBe(1); // chunk 0 dropped
+      expect(JSON.parse(buffered[199]).timestamp_ms).toBe(200);
     });
   });
 
@@ -344,7 +344,7 @@ describe('TransmissionManager', () => {
 
       const msg = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]);
       expect(msg.type).toBe('session_end');
-      expect(msg.sessionId).toBe('session-1');
+      expect(msg.session_id).toBe('session-1');
     });
 
     it('stops reconnection attempts after disconnect', async () => {
@@ -352,7 +352,7 @@ describe('TransmissionManager', () => {
       const ws = await connectManager(manager);
 
       manager.disconnect();
-      ws.simulateClose(); // onclose fires but sessionId is null → no reconnect
+      ws.simulateClose(); // onclose fires but session_id is null → no reconnect
 
       jest.advanceTimersByTime(60_000);
       expect(onLost).not.toHaveBeenCalled();
@@ -447,7 +447,7 @@ describe('TransmissionManager', () => {
 
       const initMsg = JSON.parse(ws2.sentMessages[0]);
       expect(initMsg.type).toBe('session_init');
-      expect(initMsg.sessionId).toBe('session-1');
+      expect(initMsg.session_id).toBe('session-1');
     });
 
     it('flushes buffer after ready ack on reconnect (not on open)', async () => {
@@ -471,7 +471,7 @@ describe('TransmissionManager', () => {
       expect(ws2.sentMessages).toHaveLength(2);
       const flushed = JSON.parse(ws2.sentMessages[1]);
       expect(flushed.type).toBe('audio_feature_chunk');
-      expect(flushed.timestampMs).toBe(777);
+      expect(flushed.timestamp_ms).toBe(777);
     });
 
     it('resets reconnect counter after a successful reconnect', async () => {
@@ -504,16 +504,16 @@ describe('TransmissionManager', () => {
       const ws = await connectManager(manager);
 
       ws.simulateSegment({
-        segmentId: 'seg-1',
-        sessionId: 'session-1',
+        segment_id: 'seg-1',
+        session_id: 'session-1',
         status: SegmentStatus.FINAL,
         text: 'Merhaba',
         source: ModalityType.ASR,
         confidence: 0.9,
-        timestampMs: 1000,
-        durationMs: 500,
-        createdAtMs: 1_700_000_000_000,
-        replacesSegmentId: null,
+        timestamp_ms: 1000,
+        duration_ms: 500,
+        created_at_ms: 1_700_000_000_000,
+        replaces_segment_id: null,
       });
 
       expect(store.size).toBe(1);

--- a/sozia/client/transmission/FeatureSerializer.ts
+++ b/sozia/client/transmission/FeatureSerializer.ts
@@ -28,19 +28,45 @@ function isLandmarkFrame(payload: unknown): payload is LandmarkFrame {
 export class FeatureSerializer {
   serialize(payload: LandmarkFrame | AudioFeatureChunk | PipelineHealth): string {
     if (isAudioFeatureChunk(payload)) {
-      return JSON.stringify({ type: 'audio_feature_chunk', ...payload });
+      return JSON.stringify({
+        type: 'audio_feature_chunk',
+        session_id: payload.sessionId,
+        timestamp_ms: payload.timestampMs,
+        features: payload.features,
+        feature_type: payload.featureType,
+        sample_rate_hz: payload.sampleRateHz,
+        chunk_duration_ms: payload.chunkDurationMs,
+      });
     }
     if (isLandmarkFrame(payload)) {
-      return JSON.stringify({ type: 'landmark_frame', ...payload });
+      return JSON.stringify({
+        type: 'landmark_frame',
+        session_id: payload.sessionId,
+        timestamp_ms: payload.timestampMs,
+        face_landmarks: payload.faceLandmarks,
+        left_hand_landmarks: payload.leftHandLandmarks,
+        right_hand_landmarks: payload.rightHandLandmarks,
+        pose_landmarks: payload.poseLandmarks,
+      });
     }
-    return JSON.stringify({ type: 'pipeline_health', ...payload });
+    const health = payload as PipelineHealth;
+    return JSON.stringify({
+      type: 'pipeline_health',
+      session_id: health.sessionId,
+      pipeline: health.pipeline,
+      available: health.available,
+      fps: health.fps,
+      snr: health.snr,
+      face_detected: health.faceDetected,
+      last_updated_ms: health.lastUpdatedMs,
+    });
   }
 
   sessionInit(sessionId: string, activePath: ModalityPath, apiKey: string): string {
-    return JSON.stringify({ type: 'session_init', sessionId, activePath, api_key: apiKey });
+    return JSON.stringify({ type: 'session_init', session_id: sessionId, modality_path: activePath, api_key: apiKey });
   }
 
   sessionEnd(sessionId: string): string {
-    return JSON.stringify({ type: 'session_end', sessionId });
+    return JSON.stringify({ type: 'session_end', session_id: sessionId });
   }
 }

--- a/sozia/client/transmission/SegmentReceiver.ts
+++ b/sozia/client/transmission/SegmentReceiver.ts
@@ -1,17 +1,17 @@
 import type { TranscriptSegment } from '@common/models';
 
-const REQUIRED_KEYS: ReadonlyArray<keyof TranscriptSegment> = [
-  'segmentId',
-  'sessionId',
+const REQUIRED_SNAKE_KEYS = [
+  'segment_id',
+  'session_id',
   'status',
   'text',
   'source',
   'confidence',
-  'timestampMs',
-  'durationMs',
-  'createdAtMs',
-  'replacesSegmentId',
-];
+  'timestamp_ms',
+  'duration_ms',
+  'created_at_ms',
+  'replaces_segment_id',
+] as const;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -36,10 +36,21 @@ export class SegmentReceiver {
     if (!isRecord(parsed)) return null;
     if (parsed['type'] !== 'transcript_segment') return null;
 
-    for (const key of REQUIRED_KEYS) {
+    for (const key of REQUIRED_SNAKE_KEYS) {
       if (!(key in parsed)) return null;
     }
 
-    return parsed as unknown as TranscriptSegment;
+    return {
+      segmentId:         parsed['segment_id'] as string,
+      sessionId:         parsed['session_id'] as string,
+      status:            parsed['status'] as TranscriptSegment['status'],
+      text:              parsed['text'] as string,
+      source:            parsed['source'] as TranscriptSegment['source'],
+      confidence:        parsed['confidence'] as number,
+      timestampMs:       parsed['timestamp_ms'] as number,
+      durationMs:        parsed['duration_ms'] as number,
+      createdAtMs:       parsed['created_at_ms'] as number,
+      replacesSegmentId: parsed['replaces_segment_id'] as string | null,
+    };
   }
 }

--- a/sozia/client/ui/controller/SessionController.tsx
+++ b/sozia/client/ui/controller/SessionController.tsx
@@ -237,6 +237,7 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
       if (!mounted) return;
       const health = deviceManager.current.getAudioHealth();
       actions.onPipelineHealthChanged(health);
+      transmissionManager.current?.sendHealth(health);
     }, 1000);
 
     return () => {
@@ -256,6 +257,7 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
       if (!mounted) return;
       const health = deviceManager.current.getVideoHealth();
       actions.onPipelineHealthChanged(health);
+      transmissionManager.current?.sendHealth(health);
     }, 1000);
 
     return () => {


### PR DESCRIPTION
## What does this PR do?

All outbound messages (session_init, landmark_frame, audio_feature_chunk, pipeline_health) were being serialized with camelCase field names, but the server expects snake_case. This meant every single message failed to parse on the server side — session_init got a 4002 close, feature frames hit KeyError, and health reports were silently dropped.

On the inbound side, SegmentReceiver was checking for camelCase keys in transcript_segment messages that the server never sends (it uses snake_case via dataclasses.asdict), so transcripts were always discarded as invalid.

Also hooks up sendHealth() in SessionController so pipeline health reports actually get forwarded to the server instead of only updating local UI state.

## Which package(s) does it touch?

- `sozia.client.transmission` (FeatureSerializer, SegmentReceiver)
- `sozia.client.ui` (SessionController — sendHealth wiring)

## How to test

1. Run the test suite — all 292 tests pass, transmission tests now assert against snake_case wire format
2. With a running server: start a SPEECH or SIGN session and check that session_init succeeds (no 4002), feature frames arrive, transcript segments render, and pipeline_health messages show up in server logs

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [ ] Tested locally