### PR TITLE
fix(ui): restart session from StatusBar without losing camera preview

### DIFF
--- a/sozia/client/ui/controller/SessionController.tsx
+++ b/sozia/client/ui/controller/SessionController.tsx
@@ -22,6 +22,8 @@ export type SessionControllerValue = {
   pauseSession: () => void;
   resumeSession: () => void;
   stopSession: () => void;
+  /** Stops the session then starts again with the same modality (live screen Restart). */
+  restartSession: () => Promise<void>;
   getState: () => SessionState;
   onPipelineHealthChanged: (health: PipelineHealth) => void;
   onConnectionLost: () => void;
@@ -232,6 +234,16 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
     store.clear();
   }, [store]);
 
+  const restartSession = useCallback(async () => {
+    const path = activePathRef.current ?? ModalityPath.SPEECH;
+    stopSession();
+    try {
+      await startSession(path);
+    } catch (e) {
+      if (__DEV__) console.warn('restartSession failed', e);
+    }
+  }, [stopSession, startSession]);
+
   // Poll audio pipeline health every second while a SPEECH session is active.
   // Transitions RUNNING → DEGRADED if the pipeline becomes unavailable.
   useEffect(() => {
@@ -282,6 +294,7 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
       pauseSession,
       resumeSession,
       stopSession,
+      restartSession,
       getState,
       onPipelineHealthChanged: actions.onPipelineHealthChanged,
       onConnectionLost: actions.onConnectionLost,
@@ -290,7 +303,7 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
       selectCamera,
       setCameraVideoElement,
     }),
-    [actions, activePath, enumerateDevices, getState, healthReports, pauseSession, resumeSession, selectCamera, selectMicrophone, sessionId, startSession, state, stopSession, store, setCameraVideoElement]
+    [actions, activePath, enumerateDevices, getState, healthReports, pauseSession, restartSession, resumeSession, selectCamera, selectMicrophone, sessionId, startSession, state, stopSession, store, setCameraVideoElement]
   );
 
   return <SessionControllerContext.Provider value={value}>{children}</SessionControllerContext.Provider>;

--- a/sozia/client/ui/screens/LiveTranslationScreen.tsx
+++ b/sozia/client/ui/screens/LiveTranslationScreen.tsx
@@ -20,6 +20,7 @@ export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
     healthReports,
     startSession,
     stopSession,
+    restartSession,
     pauseSession,
     resumeSession,
     store,
@@ -110,7 +111,13 @@ export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
             </TouchableOpacity>
           </View>
 
-          <StatusBar state={state} healthReports={healthReports} onRestart={stopSession} />
+          <StatusBar
+            state={state}
+            healthReports={healthReports}
+            onRestart={() => {
+              void restartSession();
+            }}
+          />
 
           <View className="relative flex-1">
             {/* Camera background */}


### PR DESCRIPTION
## What does this PR do?

- Fixes the error banner “Restart” behavior on the live screen. Restart used to call stopSession only, which cleared activePath and sessionId. The live UI hides the camera when there is no modality path, so after Restart the preview went black and the footer showed Session — · Path — even though the user stayed on live.

- This PR adds restartSession(): capture the current ModalityPath (fallback SPEECH), stopSession(), then await startSession(path) so the session comes back with the same mode, new session id, and camera preview restored. StatusBar onRestart is wired to that instead of stopSession.

## Which package(s) does it touch?

- ui (sozia.client.ui): SessionController.tsx, LiveTranslationScreen.tsx

## How to test

1. Start a Speech or Sign session and open live.
2. Force ERROR (e.g. stop inference server or use an invalid URL so WebSocket fails).
3. Tap Restart on the red status banner.
4. Confirm INITIALIZING → RUNNING (or ERROR again if server still down), camera preview returns, and Session / Path show real values again.
5. Repeat from PAUSED / DEGRADED if applicable; Restart should still recover from ERROR only (banner with Restart is ERROR-specific).
6. 

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [ ] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally