### PR TITLE
fix(transmission): ignore disconnect-before-ready in connect error handler

### DIFF
--- a/__tests__/transmission/TransmissionManager.test.ts
+++ b/__tests__/transmission/TransmissionManager.test.ts
@@ -13,7 +13,7 @@
  * Test plan reference: TP-CLIENT-TX-003
  */
 
-import { TransmissionManager } from '@/transmission/TransmissionManager';
+import { DisconnectBeforeReadyError, TransmissionManager } from '@/transmission/TransmissionManager';
 import { TranscriptStore } from '@/store/TranscriptStore';
 import { ModalityPath, SegmentStatus, ModalityType } from '@common/models';
 import type { AudioFeatureChunk, LandmarkFrame, PipelineHealth } from '@common/models';
@@ -336,6 +336,18 @@ describe('TransmissionManager', () => {
   // -- disconnect() ----------------------------------------------------------
 
   describe('disconnect()', () => {
+    it('rejects pending connect with DisconnectBeforeReadyError and does not call onLost', async () => {
+      const { manager, onLost } = makeManager();
+      const promise = manager.connect('session-1', ModalityPath.SPEECH, '');
+      const ws = FakeWebSocket.lastInstance!;
+      ws.simulateOpen();
+
+      manager.disconnect();
+
+      await expect(promise).rejects.toBeInstanceOf(DisconnectBeforeReadyError);
+      expect(onLost).not.toHaveBeenCalled();
+    });
+
     it('sends session_end before closing', async () => {
       const { manager } = makeManager();
       const ws = await connectManager(manager);

--- a/sozia/client/transmission/TransmissionManager.ts
+++ b/sozia/client/transmission/TransmissionManager.ts
@@ -28,6 +28,14 @@ interface WebSocketInstance {
 
 const WS_OPEN = 1;
 
+/** Thrown when `disconnect()` cancels a `connect()` that has not received `ready` yet. Not a network failure. */
+export class DisconnectBeforeReadyError extends Error {
+  constructor() {
+    super('TransmissionManager: disconnected before ready');
+    this.name = 'DisconnectBeforeReadyError';
+  }
+}
+
 function openSocket(url: string): WebSocketInstance {
   // WebSocket is a global in React Native and is replaced by FakeWebSocket in tests.
   return new (globalThis as any).WebSocket(url) as WebSocketInstance;
@@ -150,7 +158,7 @@ export class TransmissionManager {
     }
 
     if (this.readyResolver !== null) {
-      this.readyResolver.reject(new Error('TransmissionManager: disconnected before ready'));
+      this.readyResolver.reject(new DisconnectBeforeReadyError());
       this.readyResolver = null;
     }
 

--- a/sozia/client/transmission/index.ts
+++ b/sozia/client/transmission/index.ts
@@ -1,1 +1,1 @@
-export { TransmissionManager } from './TransmissionManager';
+export { DisconnectBeforeReadyError, TransmissionManager } from './TransmissionManager';

--- a/sozia/client/ui/controller/SessionController.tsx
+++ b/sozia/client/ui/controller/SessionController.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/pipeline/video';
 import { DeviceManager, ExpoDeviceEnumerator } from '@/device';
 import { TranscriptStore } from '@/store';
-import { TransmissionManager } from '@/transmission';
+import { DisconnectBeforeReadyError, TransmissionManager } from '@/transmission';
 import { Configuration, type IConfigurationManager } from '@/config';
 import { buildSessionActions } from './sessionActions';
 
@@ -222,7 +222,8 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
 
       // Connect in the background — the send buffer holds frames produced
       // during the connection window. onConnectionLost handles failure.
-      void transmissionManager.current.connect(newSessionId, path, apiKey).catch(() => {
+      void transmissionManager.current.connect(newSessionId, path, apiKey).catch((err: unknown) => {
+        if (err instanceof DisconnectBeforeReadyError) return;
         actions.onConnectionLost();
       });
 


### PR DESCRIPTION
## What does this PR do?

- Stops the red “session error” (`SessionState.ERROR`) banner from flashing for a moment when switching modality (e.g. sign → speech) or otherwise stopping a session while the WebSocket `connect()` is still waiting for `ready`.
- `disconnect()` already rejects the pending `connect()` promise; that is intentional cancellation, not a network failure. `SessionController` now ignores that case via `DisconnectBeforeReadyError` and only calls `onConnectionLost()` for real failures.

## Which package(s) does it touch?

- `sozia.client.transmission` — `DisconnectBeforeReadyError`, export from `index`
- `sozia.client.ui` (session controller) — `connect().catch` filters intentional cancel
- Tests — `__tests__/transmission/TransmissionManager.test.ts`


## How to test

1. Start a live session (speech or sign), wait until connected (or at least past init).
2. Switch modality or stop/restart quickly while the socket may still be connecting.
3. Confirm the red error bar does **not** flash before yellow “paused” (or idle) where applicable.
4. `npm test -- --testPathPattern=TransmissionManager.test`


## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally