### PR TITLE
fix(store): sort transcript segments by createdAtMs

### DIFF
--- a/__tests__/store/TranscriptStore.test.ts
+++ b/__tests__/store/TranscriptStore.test.ts
@@ -76,13 +76,13 @@ describe('TranscriptStore — receiveSegment and retrieval', () => {
     expect(first).toEqual(second);  // same contents
   });
 
-  it('TP-CLIENT-STORE-001d: segments are sorted by timestampMs after receiveSegment', () => {
-    store.receiveSegment(makeSegment({ timestampMs: 3000 }));
-    store.receiveSegment(makeSegment({ timestampMs: 1000 }));
-    store.receiveSegment(makeSegment({ timestampMs: 2000 }));
+  it('TP-CLIENT-STORE-001d: segments are sorted by createdAtMs after receiveSegment', () => {
+    store.receiveSegment(makeSegment({ createdAtMs: 3000 }));
+    store.receiveSegment(makeSegment({ createdAtMs: 1000 }));
+    store.receiveSegment(makeSegment({ createdAtMs: 2000 }));
 
-    const timestamps = store.getSegments().map((s) => s.timestampMs);
-    expect(timestamps).toEqual([1000, 2000, 3000]);
+    const order = store.getSegments().map((s) => s.createdAtMs);
+    expect(order).toEqual([1000, 2000, 3000]);
   });
 });
 
@@ -122,12 +122,12 @@ describe('TranscriptStore — partial → final replacement', () => {
   });
 
   it('TP-CLIENT-STORE-002b: replacement preserves display order', () => {
-    const p1 = makeSegment({ segmentId: 'p1', status: SegmentStatus.PARTIAL, timestampMs: 1000 });
-    const p2 = makeSegment({ segmentId: 'p2', status: SegmentStatus.PARTIAL, timestampMs: 2000 });
+    const p1 = makeSegment({ segmentId: 'p1', status: SegmentStatus.PARTIAL, createdAtMs: 1000 });
+    const p2 = makeSegment({ segmentId: 'p2', status: SegmentStatus.PARTIAL, createdAtMs: 2000 });
     const f1 = makeSegment({
       segmentId: 'f1',
       status: SegmentStatus.FINAL,
-      timestampMs: 1000,
+      createdAtMs: 1000,
       replacesSegmentId: 'p1',
     });
 

--- a/sozia/client/store/TranscriptStore.ts
+++ b/sozia/client/store/TranscriptStore.ts
@@ -4,10 +4,11 @@ import type { TranscriptSegment } from '@common/models';
  * Observable in-memory transcript timeline for the active session.
  *
  * Maintains an ordered list of {@link TranscriptSegment} objects sorted by
- * `timestampMs`. Handles the optimistic-then-revise pattern: when a FINAL
- * segment arrives with a non-null `replacesSegmentId`, the referenced PARTIAL
- * segment is replaced in-place (preserving display order); if the PARTIAL is
- * not found, the FINAL is appended as a new entry.
+ * `createdAtMs` (server-side Unix epoch ms, always monotonically increasing).
+ * Handles the optimistic-then-revise pattern: when a FINAL segment arrives
+ * with a non-null `replacesSegmentId`, the referenced PARTIAL segment is
+ * replaced in-place and the list is re-sorted; if the PARTIAL is not found,
+ * the FINAL is appended as a new entry.
  *
  * Collaborators: {@link TranscriptExporter} reads snapshots from this store.
  * The UI `TranscriptView` subscribes via {@link subscribe} to re-render on
@@ -31,16 +32,21 @@ export class TranscriptStore {
     if (segment.replacesSegmentId !== null) {
       const idx = this.segmentIndex.get(segment.replacesSegmentId);
       if (idx !== undefined && idx < this.segments.length && this.segments[idx].segmentId === segment.replacesSegmentId) {
+        const existing = this.segments[idx];
+        // Inherit the PARTIAL's timestampMs if the FINAL arrives with zero
+        // (some server paths omit it on standalone FINALs).
+        const resolved = segment.timestampMs > 0 ? segment : { ...segment, timestampMs: existing.timestampMs };
         this.segmentIndex.delete(segment.replacesSegmentId);
-        this.segments[idx] = segment;
-        this.segmentIndex.set(segment.segmentId, idx);
+        this.segments[idx] = resolved;
+        this.segments.sort((a, b) => a.createdAtMs - b.createdAtMs);
+        this._rebuildIndex();
         this._notify();
         return;
       }
     }
 
     this.segments.push(segment);
-    this.segments.sort((a, b) => a.timestampMs - b.timestampMs);
+    this.segments.sort((a, b) => a.createdAtMs - b.createdAtMs);
     this._rebuildIndex();
     this._notify();
   }
@@ -56,7 +62,7 @@ export class TranscriptStore {
   }
 
   /**
-   * Returns a read-only copy of the current segment list, ordered by `timestampMs`.
+   * Returns a read-only copy of the current segment list, ordered by `createdAtMs`.
    *
    * @returns Ordered array of transcript segments.
    */


### PR DESCRIPTION
## What does this PR do?

Fixes transcript segments appearing out of order in the live translation view. Segments were sorted by `timestampMs`, but the server sends `timestamp_ms` on two incompatible scales depending on the code path — audio-relative offsets for normal ASR segments and Unix epoch ms for watchdog-triggered segments. This caused mixed-scale comparisons to produce wrong sort order.

Switches the sort key to `createdAtMs`, which is always set server-side as `int(time.time() * 1000)` and is consistently Unix epoch ms across all paths.

Also fixes the replace path in `receiveSegment`, which previously skipped the sort entirely (it only updated the index in-place), so a FINAL replacing a PARTIAL would stay in the PARTIAL's visual position even when its timestamp differed.

Closes #93

## Which package(s) does it touch?

`sozia.client.store` — `TranscriptStore.receiveSegment` only.

## How to test

Start a SPEECH session with the server running. Say a few phrases and verify segments appear top-to-bottom in the order they were spoken. Trigger a watchdog flush (silence for the watchdog interval) and confirm that segment also appears in the correct position rather than jumping to the top.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally