### PR TITLE
feat(video-pipeline): degrade sign-language sessions on sustained low hand/pose visibility

### DIFF
--- a/__tests__/device/DeviceManager.test.ts
+++ b/__tests__/device/DeviceManager.test.ts
@@ -175,6 +175,7 @@ class MockVideoPipeline implements IVideoPipeline {
       fps: this.running ? 30 : 0,
       snr: null,
       faceDetected: this.running ? true : null,
+      faceFrameRatio: this.running ? 1 : null,
       lastUpdatedMs: Date.now(),
     };
   }

--- a/__tests__/pipeline/video/NativeCameraView.helpers.test.ts
+++ b/__tests__/pipeline/video/NativeCameraView.helpers.test.ts
@@ -97,6 +97,20 @@ describe('normalizeLandmarkFrame', () => {
     expect(result!.poseLandmarks).toHaveLength(33);
   });
 
+  it('passes through valid faceMeanVisibility', () => {
+    const raw = makeValidRaw({ faceMeanVisibility: 0.65 });
+    const result = normalizeLandmarkFrame(raw);
+    expect(result).not.toBeNull();
+    expect(result!.faceMeanVisibility).toBe(0.65);
+  });
+
+  it('drops invalid faceMeanVisibility', () => {
+    const raw = makeValidRaw({ faceMeanVisibility: 1.5 });
+    const result = normalizeLandmarkFrame(raw);
+    expect(result).not.toBeNull();
+    expect(result!.faceMeanVisibility).toBeUndefined();
+  });
+
   it('returns null when sessionId is missing', () => {
     const raw = makeValidRaw({ sessionId: undefined });
     expect(normalizeLandmarkFrame(raw)).toBeNull();

--- a/__tests__/pipeline/video/VideoPipeline.test.ts
+++ b/__tests__/pipeline/video/VideoPipeline.test.ts
@@ -67,6 +67,7 @@ describe('TrackingHealthMonitor', () => {
     expect(health.pipeline).toBe('video');
     expect(health.available).toBe(true);
     expect(health.snr).toBeNull();
+    expect(health.faceFrameRatio).toBeCloseTo(2 / 3, 5);
   });
 
   it('reports faceDetected=false when landmarks are null', () => {
@@ -75,6 +76,178 @@ describe('TrackingHealthMonitor', () => {
 
     const health = monitor.getHealth('s1');
     expect(health.faceDetected).toBe(false);
+  });
+
+  it('sets signVisibilitySustainedLow after both hands stay low for SIGN_VISIBILITY_LOW_MIN_MS', () => {
+    const monitor = new TrackingHealthMonitor(5000);
+    const base = 10_000;
+    const mk = (ts: number, l: number, r: number, p: number): LandmarkFrame => ({
+      sessionId: 's1',
+      timestampMs: ts,
+      faceLandmarks: [[0, 0, 0]],
+      leftHandLandmarks: [[0, 0, 0]],
+      rightHandLandmarks: [[0, 0, 0]],
+      poseLandmarks: [[0, 0, 0]],
+      leftHandVisibilityMean: l,
+      rightHandVisibilityMean: r,
+      poseVisibilityMean: p,
+    });
+    for (let i = 0; i < 50; i++) {
+      monitor.update(mk(base + i * 34, 0.2, 0.2, 0.95));
+    }
+    const health = monitor.getHealth('s1');
+    expect(health.signVisibilitySustainedLow).toBe(true);
+    expect(health.signVisibilityMessageKeys).toEqual(['health.signLowHands']);
+  });
+
+  it('hands-only alert when pose is above pose threshold but hands are low', () => {
+    const monitor = new TrackingHealthMonitor(5000);
+    const base = 15_000;
+    const mk = (ts: number): LandmarkFrame => ({
+      sessionId: 's1',
+      timestampMs: ts,
+      faceLandmarks: [[0, 0, 0]],
+      leftHandLandmarks: [[0, 0, 0]],
+      rightHandLandmarks: [[0, 0, 0]],
+      poseLandmarks: [[0, 0, 0]],
+      leftHandVisibilityMean: 0.2,
+      rightHandVisibilityMean: 0.2,
+      poseVisibilityMean: 0.95,
+    });
+    for (let i = 0; i < 50; i++) {
+      monitor.update(mk(base + i * 34));
+    }
+    expect(monitor.getHealth('s1').signVisibilityMessageKeys).toEqual(['health.signLowHands']);
+  });
+
+  it('hands-only alert when a single detected hand is below threshold', () => {
+    const monitor = new TrackingHealthMonitor(5000);
+    const base = 16_000;
+    const mk = (ts: number): LandmarkFrame => ({
+      sessionId: 's1',
+      timestampMs: ts,
+      faceLandmarks: [[0, 0, 0]],
+      leftHandLandmarks: [[0, 0, 0]],
+      rightHandLandmarks: null,
+      poseLandmarks: [[0, 0, 0]],
+      leftHandVisibilityMean: 0.2,
+      poseVisibilityMean: 0.95,
+    });
+    for (let i = 0; i < 50; i++) {
+      monitor.update(mk(base + i * 34));
+    }
+    expect(monitor.getHealth('s1').signVisibilityMessageKeys).toEqual(['health.signLowHands']);
+  });
+
+  it('hands alert when pose is tracked but neither hand mesh is present', () => {
+    const monitor = new TrackingHealthMonitor(5000);
+    const base = 50_000;
+    const mk = (ts: number): LandmarkFrame => ({
+      sessionId: 's1',
+      timestampMs: ts,
+      faceLandmarks: [[0, 0, 0]],
+      leftHandLandmarks: null,
+      rightHandLandmarks: null,
+      poseLandmarks: [[0, 0, 0]],
+      poseVisibilityMean: 0.9,
+    });
+    for (let i = 0; i < 50; i++) {
+      monitor.update(mk(base + i * 34));
+    }
+    expect(monitor.getHealth('s1').signVisibilityMessageKeys).toEqual(['health.signLowHands']);
+  });
+
+  it('general framing when no hands detected and pose visibility is low', () => {
+    const monitor = new TrackingHealthMonitor(5000);
+    const base = 60_000;
+    const mk = (ts: number): LandmarkFrame => ({
+      sessionId: 's1',
+      timestampMs: ts,
+      faceLandmarks: [[0, 0, 0]],
+      leftHandLandmarks: null,
+      rightHandLandmarks: null,
+      poseLandmarks: [[0, 0, 0]],
+      poseVisibilityMean: 0.2,
+    });
+    for (let i = 0; i < 50; i++) {
+      monitor.update(mk(base + i * 34));
+    }
+    expect(monitor.getHealth('s1').signVisibilityMessageKeys).toEqual(['health.signLowSigningFraming']);
+  });
+
+  it('sets signVisibility from pose-only sustained low visibility', () => {
+    const monitor = new TrackingHealthMonitor(5000);
+    const base = 20_000;
+    const mk = (ts: number): LandmarkFrame => ({
+      sessionId: 's1',
+      timestampMs: ts,
+      faceLandmarks: [[0, 0, 0]],
+      leftHandLandmarks: [[0, 0, 0]],
+      rightHandLandmarks: [[0, 0, 0]],
+      poseLandmarks: [[0, 0, 0]],
+      leftHandVisibilityMean: 0.95,
+      rightHandVisibilityMean: 0.95,
+      poseVisibilityMean: 0.2,
+    });
+    for (let i = 0; i < 50; i++) {
+      monitor.update(mk(base + i * 34));
+    }
+    const health = monitor.getHealth('s1');
+    expect(health.signVisibilitySustainedLow).toBe(true);
+    expect(health.signVisibilityMessageKeys).toEqual(['health.signLowUpperBody']);
+  });
+
+  it('returns a general framing key when both hands and pose stay low', () => {
+    const monitor = new TrackingHealthMonitor(5000);
+    const base = 40_000;
+    const mk = (ts: number): LandmarkFrame => ({
+      sessionId: 's1',
+      timestampMs: ts,
+      faceLandmarks: [[0, 0, 0]],
+      leftHandLandmarks: [[0, 0, 0]],
+      rightHandLandmarks: [[0, 0, 0]],
+      poseLandmarks: [[0, 0, 0]],
+      leftHandVisibilityMean: 0.2,
+      rightHandVisibilityMean: 0.2,
+      poseVisibilityMean: 0.2,
+    });
+    for (let i = 0; i < 50; i++) {
+      monitor.update(mk(base + i * 34));
+    }
+    expect(monitor.getHealth('s1').signVisibilityMessageKeys).toEqual(['health.signLowSigningFraming']);
+  });
+
+  it('clears sign sustained low when visibility recovers', () => {
+    const monitor = new TrackingHealthMonitor(5000);
+    const base = 30_000;
+    const low = (ts: number): LandmarkFrame => ({
+      sessionId: 's1',
+      timestampMs: ts,
+      faceLandmarks: [[0, 0, 0]],
+      leftHandLandmarks: [[0, 0, 0]],
+      rightHandLandmarks: [[0, 0, 0]],
+      poseLandmarks: [[0, 0, 0]],
+      leftHandVisibilityMean: 0.2,
+      rightHandVisibilityMean: 0.2,
+      poseVisibilityMean: 0.95,
+    });
+    const ok = (ts: number): LandmarkFrame => ({
+      sessionId: 's1',
+      timestampMs: ts,
+      faceLandmarks: [[0, 0, 0]],
+      leftHandLandmarks: [[0, 0, 0]],
+      rightHandLandmarks: [[0, 0, 0]],
+      poseLandmarks: [[0, 0, 0]],
+      leftHandVisibilityMean: 0.95,
+      rightHandVisibilityMean: 0.95,
+      poseVisibilityMean: 0.95,
+    });
+    for (let i = 0; i < 50; i++) monitor.update(low(base + i * 34));
+    expect(monitor.getHealth('s1').signVisibilitySustainedLow).toBe(true);
+    monitor.update(ok(base + 50 * 34));
+    const health = monitor.getHealth('s1');
+    expect(health.signVisibilitySustainedLow).toBe(false);
+    expect(health.signVisibilityMessageKeys).toBeNull();
   });
 });
 

--- a/__tests__/transmission/FeatureSerializer.test.ts
+++ b/__tests__/transmission/FeatureSerializer.test.ts
@@ -93,7 +93,7 @@ describe('FeatureSerializer', () => {
       expect(result.type).toBe('pipeline_health');
     });
 
-    it('preserves all LandmarkFrame fields as snake_case', () => {
+    it('preserves all LandmarkFrame wire fields as snake_case', () => {
       const frame = makeLandmarkFrame();
       const result = JSON.parse(serializer.serialize(frame));
       expect(result.session_id).toBe(frame.sessionId);
@@ -102,6 +102,20 @@ describe('FeatureSerializer', () => {
       expect(result.left_hand_landmarks).toBeNull();
       expect(result.right_hand_landmarks).toEqual(frame.rightHandLandmarks);
       expect(result.pose_landmarks).toBeNull();
+    });
+
+    it('does not serialize faceMeanVisibility (client-only)', () => {
+      const frame: LandmarkFrame = {
+        sessionId: 'session-1',
+        timestampMs: 1000,
+        faceMeanVisibility: 0.85,
+        faceLandmarks: [[0.1, 0.2, 0.3]],
+        leftHandLandmarks: null,
+        rightHandLandmarks: null,
+        poseLandmarks: null,
+      };
+      const result = JSON.parse(serializer.serialize(frame));
+      expect(result.face_mean_visibility).toBeUndefined();
     });
 
     it('preserves all AudioFeatureChunk fields as snake_case', () => {

--- a/__tests__/ui/components/StatusBar.test.ts
+++ b/__tests__/ui/components/StatusBar.test.ts
@@ -91,6 +91,38 @@ describe('getStatusBanner', () => {
     expect(banner!.messageKey).toBe('health.cameraObstructed');
   });
 
+  it('SPEECH: video rolling-unavailable but live stream prefers no-face over obstructed', () => {
+    const health = [
+      makeVideoHealth({
+        available: false,
+        fps: 28,
+        faceFrameRatio: 0.1,
+        faceDetected: false,
+      }),
+    ];
+    const banner = getStatusBanner(SessionState.DEGRADED, health, ModalityPath.SPEECH);
+    expect(banner!.messageKey).toBe('health.noFaceDetected');
+  });
+
+  it('SPEECH: video rolling-unavailable but live stream prefers keep-face when ratio low and last had face', () => {
+    const health = [
+      makeVideoHealth({
+        available: false,
+        fps: 28,
+        faceFrameRatio: 0.35,
+        faceDetected: true,
+      }),
+    ];
+    const banner = getStatusBanner(SessionState.DEGRADED, health, ModalityPath.SPEECH);
+    expect(banner!.messageKey).toBe('health.keepFaceInCamera');
+  });
+
+  it('SPEECH: truly dead video (low fps) still shows obstructed', () => {
+    const health = [makeVideoHealth({ available: false, fps: 0, faceFrameRatio: 0 })];
+    const banner = getStatusBanner(SessionState.DEGRADED, health, ModalityPath.SPEECH);
+    expect(banner!.messageKey).toBe('health.cameraObstructed');
+  });
+
   it('returns low-signal DEGRADED banner when audio SNR is low', () => {
     const health = [makeAudioHealth({ available: true, snr: 3 })];
     const banner = getStatusBanner(SessionState.DEGRADED, health, null);

--- a/__tests__/ui/components/StatusBar.test.ts
+++ b/__tests__/ui/components/StatusBar.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { SessionState, type PipelineHealth } from '@common/models';
+import { ModalityPath, SessionState, type PipelineHealth } from '@common/models';
 import {
   getStatusBanner,
   type Banner,
@@ -35,66 +35,88 @@ function makeVideoHealth(overrides: Partial<PipelineHealth> = {}): PipelineHealt
 
 describe('getStatusBanner', () => {
   it('returns RUNNING banner for RUNNING state', () => {
-    const banner = getStatusBanner(SessionState.RUNNING, []);
+    const banner = getStatusBanner(SessionState.RUNNING, [], null);
     expect(banner).not.toBeNull();
     expect(banner!.messageKey).toBe('health.sessionActive');
     expect(banner!.bg).toContain('green');
   });
 
   it('returns INITIALIZING banner', () => {
-    const banner = getStatusBanner(SessionState.INITIALIZING, []);
+    const banner = getStatusBanner(SessionState.INITIALIZING, [], null);
     expect(banner).not.toBeNull();
     expect(banner!.bg).toContain('blue');
   });
 
   it('returns PAUSED banner', () => {
-    const banner = getStatusBanner(SessionState.PAUSED, []);
+    const banner = getStatusBanner(SessionState.PAUSED, [], null);
     expect(banner).not.toBeNull();
     expect(banner!.bg).toContain('yellow');
   });
 
   it('returns null for IDLE state', () => {
-    expect(getStatusBanner(SessionState.IDLE, [])).toBeNull();
+    expect(getStatusBanner(SessionState.IDLE, [], null)).toBeNull();
   });
 
   it('returns ERROR banner with showRestart flag', () => {
-    const banner = getStatusBanner(SessionState.ERROR, []);
+    const banner = getStatusBanner(SessionState.ERROR, [], null);
     expect(banner).not.toBeNull();
     expect(banner!.bg).toContain('red');
     expect(banner!.showRestart).toBe(true);
   });
 
   it('returns generic DEGRADED banner when no health reports', () => {
-    const banner = getStatusBanner(SessionState.DEGRADED, []);
+    const banner = getStatusBanner(SessionState.DEGRADED, [], null);
     expect(banner).not.toBeNull();
     expect(banner!.bg).toContain('orange');
   });
 
   it('returns mic-specific DEGRADED banner when audio unavailable', () => {
     const health = [makeAudioHealth({ available: false })];
-    const banner = getStatusBanner(SessionState.DEGRADED, health);
+    const banner = getStatusBanner(SessionState.DEGRADED, health, null);
     expect(banner).not.toBeNull();
     expect(banner!.messageKey).toBe('health.microphoneUnavailable');
   });
 
   it('returns no-face DEGRADED banner when video has no face detected', () => {
-    const health = [makeVideoHealth({ available: true, faceDetected: false })];
-    const banner = getStatusBanner(SessionState.DEGRADED, health);
+    const health = [makeVideoHealth({ available: true, faceDetected: false, faceFrameRatio: 0.9 })];
+    const banner = getStatusBanner(SessionState.DEGRADED, health, ModalityPath.SPEECH);
     expect(banner).not.toBeNull();
     expect(banner!.messageKey).toBe('health.noFaceDetected');
   });
 
   it('returns camera-obstructed DEGRADED banner when video unavailable', () => {
     const health = [makeVideoHealth({ available: false })];
-    const banner = getStatusBanner(SessionState.DEGRADED, health);
+    const banner = getStatusBanner(SessionState.DEGRADED, health, null);
     expect(banner).not.toBeNull();
     expect(banner!.messageKey).toBe('health.cameraObstructed');
   });
 
   it('returns low-signal DEGRADED banner when audio SNR is low', () => {
     const health = [makeAudioHealth({ available: true, snr: 3 })];
-    const banner = getStatusBanner(SessionState.DEGRADED, health);
+    const banner = getStatusBanner(SessionState.DEGRADED, health, null);
     expect(banner).not.toBeNull();
     expect(banner!.messageKey).toBe('health.lowSignalQuality');
+  });
+
+  it('returns keep-face DEGRADED banner on SPEECH when face frame ratio is low', () => {
+    const health = [makeVideoHealth({ available: true, faceFrameRatio: 0.35, faceDetected: true })];
+    const banner = getStatusBanner(SessionState.DEGRADED, health, ModalityPath.SPEECH);
+    expect(banner).not.toBeNull();
+    expect(banner!.messageKey).toBe('health.keepFaceInCamera');
+  });
+
+  it('returns SIGN DEGRADED banner with combined framing key when both hands and pose are bad', () => {
+    const health = [
+      makeVideoHealth({
+        available: true,
+        faceDetected: true,
+        faceFrameRatio: 0.9,
+        signVisibilityMessageKeys: ['health.signLowSigningFraming'],
+      }),
+    ];
+    const banner = getStatusBanner(SessionState.DEGRADED, health, ModalityPath.SIGN);
+    expect(banner).not.toBeNull();
+    expect(banner!.messageKeys).toEqual(['health.signLowSigningFraming']);
+    expect(banner!.messageKey).toBe('health.signLowSigningFraming');
   });
 });

--- a/__tests__/ui/controller/SessionController.test.ts
+++ b/__tests__/ui/controller/SessionController.test.ts
@@ -49,6 +49,7 @@ describe('sessionActions — onPipelineHealthChanged', () => {
       setState: (s) => stateUpdates.push(s),
       getHealthReports: () => healthUpdates.length > 0 ? healthUpdates[healthUpdates.length - 1] : [],
       setHealthReports: (h) => healthUpdates.push(h),
+      getModalityPath: () => null,
     });
   });
 
@@ -73,6 +74,52 @@ describe('sessionActions — onPipelineHealthChanged', () => {
     expect(stateUpdates).toContain(SessionState.DEGRADED);
   });
 
+  it('transitions RUNNING → DEGRADED on SPEECH when face frame ratio is below threshold', () => {
+    let modality: ModalityPath | null = ModalityPath.SPEECH;
+    actions = buildSessionActions({
+      getState: () => (stateUpdates.length > 0 ? stateUpdates[stateUpdates.length - 1] : SessionState.RUNNING),
+      setState: (s) => stateUpdates.push(s),
+      getHealthReports: () => (healthUpdates.length > 0 ? healthUpdates[healthUpdates.length - 1] : []),
+      setHealthReports: (h) => healthUpdates.push(h),
+      getModalityPath: () => modality,
+    });
+    actions.onPipelineHealthChanged(makeVideoHealth({ available: true, faceFrameRatio: 0.4 }));
+    expect(stateUpdates).toContain(SessionState.DEGRADED);
+  });
+
+  it('does not degrade on SIGN when face frame ratio is low', () => {
+    let modality: ModalityPath | null = ModalityPath.SIGN;
+    actions = buildSessionActions({
+      getState: () => (stateUpdates.length > 0 ? stateUpdates[stateUpdates.length - 1] : SessionState.RUNNING),
+      setState: (s) => stateUpdates.push(s),
+      getHealthReports: () => (healthUpdates.length > 0 ? healthUpdates[healthUpdates.length - 1] : []),
+      setHealthReports: (h) => healthUpdates.push(h),
+      getModalityPath: () => modality,
+    });
+    actions.onPipelineHealthChanged(makeVideoHealth({ available: true, faceFrameRatio: 0.2 }));
+    expect(stateUpdates.filter((s) => s === SessionState.DEGRADED)).toHaveLength(0);
+  });
+
+  it('transitions RUNNING → DEGRADED on SIGN when sign visibility has been sustained low', () => {
+    let modality: ModalityPath | null = ModalityPath.SIGN;
+    actions = buildSessionActions({
+      getState: () => (stateUpdates.length > 0 ? stateUpdates[stateUpdates.length - 1] : SessionState.RUNNING),
+      setState: (s) => stateUpdates.push(s),
+      getHealthReports: () => (healthUpdates.length > 0 ? healthUpdates[healthUpdates.length - 1] : []),
+      setHealthReports: (h) => healthUpdates.push(h),
+      getModalityPath: () => modality,
+    });
+    actions.onPipelineHealthChanged(
+      makeVideoHealth({
+        available: true,
+        faceFrameRatio: 0.9,
+        signVisibilitySustainedLow: true,
+        signVisibilityMessageKeys: ['health.signLowHands'],
+      }),
+    );
+    expect(stateUpdates).toContain(SessionState.DEGRADED);
+  });
+
   it('does NOT transition to DEGRADED if already in ERROR state', () => {
     stateUpdates.push(SessionState.ERROR);
     actions = buildSessionActions({
@@ -80,6 +127,7 @@ describe('sessionActions — onPipelineHealthChanged', () => {
       setState: (s) => stateUpdates.push(s),
       getHealthReports: () => [],
       setHealthReports: (h) => healthUpdates.push(h),
+      getModalityPath: () => null,
     });
     actions.onPipelineHealthChanged(makeAudioHealth({ available: false }));
     const nonError = stateUpdates.filter((s) => s !== SessionState.ERROR);
@@ -95,6 +143,7 @@ describe('sessionActions — onConnectionLost', () => {
       setState: (s) => stateUpdates.push(s),
       getHealthReports: () => [],
       setHealthReports: () => {},
+      getModalityPath: () => null,
     });
     actions.onConnectionLost();
     expect(stateUpdates).toContain(SessionState.ERROR);

--- a/sozia/client/device/DeviceManager.ts
+++ b/sozia/client/device/DeviceManager.ts
@@ -204,6 +204,9 @@ export class DeviceManager {
         fps: null,
         snr: null,
         faceDetected: null,
+        faceFrameRatio: null,
+        signVisibilitySustainedLow: false,
+        signVisibilityMessageKeys: null,
         lastUpdatedMs: 0,
       };
     }

--- a/sozia/client/pipeline/video/TrackingHealthMonitor.ts
+++ b/sozia/client/pipeline/video/TrackingHealthMonitor.ts
@@ -1,9 +1,22 @@
 import type { LandmarkFrame, PipelineHealth } from '@common/models';
+import {
+  SIGN_HAND_VISIBILITY_MIN,
+  SIGN_POSE_VISIBILITY_MIN,
+  SIGN_VISIBILITY_LOW_MIN_MS,
+} from '@/ui/healthThresholds';
+import { signVisibilityBannerKeys } from './signVisibilityBanner';
 
 type RecentFrame = {
   timestampMs: number;
   detected: boolean;
   faceDetected: boolean;
+};
+
+type SignParts = {
+  handsAnyBad: boolean;
+  handsBothMissing: boolean;
+  poseBad: boolean;
+  combinedBad: boolean;
 };
 
 /**
@@ -12,6 +25,10 @@ type RecentFrame = {
 export class TrackingHealthMonitor {
   private readonly windowSizeMs: number;
   private recentFrames: RecentFrame[] = [];
+  /** Start of current continuous interval where SIGN combined visibility is low. */
+  private combinedLowSinceMs: number | null = null;
+  private lastSignSustained = false;
+  private lastSignMessageKeys: string[] | null = null;
 
   constructor(windowSizeMs = 2000) {
     this.windowSizeMs = windowSizeMs;
@@ -31,6 +48,22 @@ export class TrackingHealthMonitor {
 
     this.recentFrames.push(entry);
     this.trim(ts);
+
+    const sign = this.evaluateSignParts(landmarks);
+    if (sign.combinedBad) {
+      if (this.combinedLowSinceMs === null) this.combinedLowSinceMs = ts;
+    } else {
+      this.combinedLowSinceMs = null;
+    }
+
+    const sustained =
+      this.combinedLowSinceMs !== null &&
+      ts - this.combinedLowSinceMs >= SIGN_VISIBILITY_LOW_MIN_MS;
+
+    this.lastSignSustained = sustained;
+    this.lastSignMessageKeys = sustained
+      ? signVisibilityBannerKeys(sign.handsAnyBad, sign.poseBad, sign.handsBothMissing)
+      : null;
   }
 
   getHealth(sessionId: string): PipelineHealth {
@@ -42,6 +75,9 @@ export class TrackingHealthMonitor {
         fps: 0,
         snr: null,
         faceDetected: null,
+        faceFrameRatio: null,
+        signVisibilitySustainedLow: false,
+        signVisibilityMessageKeys: null,
         lastUpdatedMs: 0,
       };
     }
@@ -52,6 +88,8 @@ export class TrackingHealthMonitor {
     const fps = Math.round((this.recentFrames.length / (spanMs / 1000)) * 10) / 10;
     const detectedCount = this.recentFrames.filter((f) => f.detected).length;
     const available = detectedCount / this.recentFrames.length > 0.5;
+    const faceDetectedCount = this.recentFrames.filter((f) => f.faceDetected).length;
+    const faceFrameRatio = faceDetectedCount / this.recentFrames.length;
 
     return {
       sessionId,
@@ -60,8 +98,44 @@ export class TrackingHealthMonitor {
       fps,
       snr: null,
       faceDetected: last.faceDetected,
+      faceFrameRatio,
+      signVisibilitySustainedLow: this.lastSignSustained,
+      signVisibilityMessageKeys: this.lastSignSustained ? this.lastSignMessageKeys : null,
       lastUpdatedMs: last.timestampMs,
     };
+  }
+
+  /**
+   * SIGN: hands use `SIGN_HAND_VISIBILITY_MIN`; pose uses `SIGN_POSE_VISIBILITY_MIN`.
+   * `handsBothMissing`: pose mesh present but neither hand mesh — user should bring hands in frame.
+   * Any detected hand below threshold is treated as a hand issue.
+   * Missing visibility means on a detected part (e.g. native) default to OK so we do not false-degrade.
+   */
+  private evaluateSignParts(landmarks: LandmarkFrame | null): SignParts {
+    const gn = (v: unknown): number | null =>
+      typeof v === 'number' && Number.isFinite(v) ? v : null;
+
+    const hasLeft = landmarks?.leftHandLandmarks !== null;
+    const hasRight = landmarks?.rightHandLandmarks !== null;
+    const hasPose = landmarks?.poseLandmarks !== null;
+
+    const left = gn(landmarks?.leftHandVisibilityMean);
+    const right = gn(landmarks?.rightHandVisibilityMean);
+    const pose = gn(landmarks?.poseVisibilityMean);
+
+    const leftScore = hasLeft ? (left ?? 1) : null;
+    const rightScore = hasRight ? (right ?? 1) : null;
+    const poseScore = hasPose ? (pose ?? 1) : null;
+
+    const leftBad = hasLeft && leftScore !== null && leftScore < SIGN_HAND_VISIBILITY_MIN;
+    const rightBad = hasRight && rightScore !== null && rightScore < SIGN_HAND_VISIBILITY_MIN;
+    const poseBad = hasPose && poseScore !== null && poseScore < SIGN_POSE_VISIBILITY_MIN;
+
+    const handsAnyBad = leftBad || rightBad;
+    const handsBothMissing = hasPose && !hasLeft && !hasRight;
+    const combinedBad = handsAnyBad || poseBad || handsBothMissing;
+
+    return { handsAnyBad, handsBothMissing, poseBad, combinedBad };
   }
 
   private trim(nowMs: number): void {
@@ -69,4 +143,3 @@ export class TrackingHealthMonitor {
     this.recentFrames = this.recentFrames.filter((f) => f.timestampMs >= cutoff);
   }
 }
-

--- a/sozia/client/pipeline/video/VideoPipeline.ts
+++ b/sozia/client/pipeline/video/VideoPipeline.ts
@@ -7,6 +7,8 @@ import {
 import { TrackingHealthMonitor } from './TrackingHealthMonitor';
 
 const DEFAULT_TARGET_FPS = 30;
+/** Min interval between visibility metric console logs (avoids log spam at 30 Hz). */
+const VISIBILITY_METRICS_LOG_INTERVAL_MS = 1000;
 
 /** Opaque camera handle. Concrete camera APIs are hidden behind this shape. */
 export interface RawMediaHandle {
@@ -38,6 +40,7 @@ export class VideoPipeline implements IVideoPipeline {
   private cameraHandle: RawMediaHandle | null = null;
   private transmissionManager: TransmissionManager | null = null;
   private frameTimer: ReturnType<typeof setInterval> | null = null;
+  private lastVisibilityLogMs = 0;
 
   constructor(
     extractor: LandmarkExtractor = new LandmarkExtractor(),
@@ -88,6 +91,7 @@ export class VideoPipeline implements IVideoPipeline {
     this.sessionId = '';
     this.cameraHandle = null;
     this.transmissionManager = null;
+    this.lastVisibilityLogMs = 0;
   }
 
   getHealth(): PipelineHealth {
@@ -99,6 +103,9 @@ export class VideoPipeline implements IVideoPipeline {
         fps: 0,
         snr: null,
         faceDetected: null,
+        faceFrameRatio: null,
+        signVisibilitySustainedLow: false,
+        signVisibilityMessageKeys: null,
         lastUpdatedMs: 0,
       };
     }
@@ -118,6 +125,7 @@ export class VideoPipeline implements IVideoPipeline {
       const landmarkFrame = this.toLandmarkFrame(extracted, rawFrame.timestampMs);
 
       this.healthMonitor.update(landmarkFrame);
+      this.maybeLogVisibilityMetrics(landmarkFrame);
       if (landmarkFrame !== null) {
         this.transmissionManager?.sendFeatures(landmarkFrame);
       }
@@ -142,15 +150,40 @@ export class VideoPipeline implements IVideoPipeline {
     };
   }
 
+  private maybeLogVisibilityMetrics(landmarkFrame: LandmarkFrame | null): void {
+    if (landmarkFrame === null) return;
+    const now = Date.now();
+    if (now - this.lastVisibilityLogMs < VISIBILITY_METRICS_LOG_INTERVAL_MS) return;
+    this.lastVisibilityLogMs = now;
+
+    const fmt = (v: number | null | undefined): string =>
+      typeof v === 'number' && Number.isFinite(v) ? v.toFixed(3) : '—';
+
+    // eslint-disable-next-line no-console -- intentional debug visibility metrics
+    console.log(
+      '[VideoPipeline] visibility',
+      'face=', fmt(landmarkFrame.faceMeanVisibility),
+      'pose=', fmt(landmarkFrame.poseVisibilityMean),
+      'leftHand=', fmt(landmarkFrame.leftHandVisibilityMean),
+      'rightHand=', fmt(landmarkFrame.rightHandVisibilityMean),
+      'sessionId',
+      landmarkFrame.sessionId,
+    );
+  }
+
   private toLandmarkFrame(extracted: LandmarkFrame | null, timestampMs: number): LandmarkFrame | null {
     if (!extracted) return null;
     return {
       sessionId: extracted.sessionId || this.sessionId,
       timestampMs,
+      faceMeanVisibility: extracted.faceMeanVisibility ?? null,
       faceLandmarks: extracted.faceLandmarks,
       leftHandLandmarks: extracted.leftHandLandmarks,
       rightHandLandmarks: extracted.rightHandLandmarks,
       poseLandmarks: extracted.poseLandmarks,
+      leftHandVisibilityMean: extracted.leftHandVisibilityMean ?? null,
+      rightHandVisibilityMean: extracted.rightHandVisibilityMean ?? null,
+      poseVisibilityMean: extracted.poseVisibilityMean ?? null,
     };
   }
 }

--- a/sozia/client/pipeline/video/VideoPipeline.ts
+++ b/sozia/client/pipeline/video/VideoPipeline.ts
@@ -7,8 +7,6 @@ import {
 import { TrackingHealthMonitor } from './TrackingHealthMonitor';
 
 const DEFAULT_TARGET_FPS = 30;
-/** Min interval between visibility metric console logs (avoids log spam at 30 Hz). */
-const VISIBILITY_METRICS_LOG_INTERVAL_MS = 1000;
 
 /** Opaque camera handle. Concrete camera APIs are hidden behind this shape. */
 export interface RawMediaHandle {
@@ -40,7 +38,6 @@ export class VideoPipeline implements IVideoPipeline {
   private cameraHandle: RawMediaHandle | null = null;
   private transmissionManager: TransmissionManager | null = null;
   private frameTimer: ReturnType<typeof setInterval> | null = null;
-  private lastVisibilityLogMs = 0;
 
   constructor(
     extractor: LandmarkExtractor = new LandmarkExtractor(),
@@ -91,7 +88,6 @@ export class VideoPipeline implements IVideoPipeline {
     this.sessionId = '';
     this.cameraHandle = null;
     this.transmissionManager = null;
-    this.lastVisibilityLogMs = 0;
   }
 
   getHealth(): PipelineHealth {
@@ -125,7 +121,6 @@ export class VideoPipeline implements IVideoPipeline {
       const landmarkFrame = this.toLandmarkFrame(extracted, rawFrame.timestampMs);
 
       this.healthMonitor.update(landmarkFrame);
-      this.maybeLogVisibilityMetrics(landmarkFrame);
       if (landmarkFrame !== null) {
         this.transmissionManager?.sendFeatures(landmarkFrame);
       }
@@ -148,27 +143,6 @@ export class VideoPipeline implements IVideoPipeline {
       height: 0,
       data: null,
     };
-  }
-
-  private maybeLogVisibilityMetrics(landmarkFrame: LandmarkFrame | null): void {
-    if (landmarkFrame === null) return;
-    const now = Date.now();
-    if (now - this.lastVisibilityLogMs < VISIBILITY_METRICS_LOG_INTERVAL_MS) return;
-    this.lastVisibilityLogMs = now;
-
-    const fmt = (v: number | null | undefined): string =>
-      typeof v === 'number' && Number.isFinite(v) ? v.toFixed(3) : '—';
-
-    // eslint-disable-next-line no-console -- intentional debug visibility metrics
-    console.log(
-      '[VideoPipeline] visibility',
-      'face=', fmt(landmarkFrame.faceMeanVisibility),
-      'pose=', fmt(landmarkFrame.poseVisibilityMean),
-      'leftHand=', fmt(landmarkFrame.leftHandVisibilityMean),
-      'rightHand=', fmt(landmarkFrame.rightHandVisibilityMean),
-      'sessionId',
-      landmarkFrame.sessionId,
-    );
   }
 
   private toLandmarkFrame(extracted: LandmarkFrame | null, timestampMs: number): LandmarkFrame | null {

--- a/sozia/client/pipeline/video/WebMediaPipeLandmarkBackend.ts
+++ b/sozia/client/pipeline/video/WebMediaPipeLandmarkBackend.ts
@@ -53,6 +53,92 @@ function toLandmarkArray(
   return landmarks.map((lm) => [lm.x, lm.y, lm.z]);
 }
 
+/**
+ * Face Landmarker commonly reports `visibility === 0` for all points (WASM / Tasks API;
+ * see https://github.com/google-ai-edge/mediapipe/issues/5450). Above this threshold we
+ * trust the model; otherwise we use a geometric proxy from normalized x/y.
+ */
+const FACE_VISIBILITY_MODEL_TRUST_EPS = 1e-3;
+
+/** [0, 1]: 1 near frame edges inward, ~0 on the normalized border (cropping). */
+function geometricFaceEdgeScore(x: number, y: number): number {
+  const edgeDist = Math.min(x, 1 - x, y, 1 - y);
+  return Math.min(1, 4 * Math.max(0, edgeDist));
+}
+
+/** [0, 1]: 1 near image center; helps when the face sits mid-frame but some ring points hug the outline. */
+function geometricFaceCenterScore(x: number, y: number): number {
+  const d = Math.hypot(x - 0.5, y - 0.5);
+  return Math.max(0, Math.min(1, 1 - 1.85 * d));
+}
+
+function geometricFaceFramingScore(x: number, y: number): number {
+  return Math.max(geometricFaceEdgeScore(x, y), geometricFaceCenterScore(x, y));
+}
+
+function isFiniteLandmarkXY(lm: { x?: unknown; y?: unknown }): boolean {
+  return (
+    typeof lm.x === 'number' &&
+    typeof lm.y === 'number' &&
+    Number.isFinite(lm.x) &&
+    Number.isFinite(lm.y)
+  );
+}
+
+type RawNormLm = { x?: number; y?: number; z?: number; visibility?: number };
+
+/**
+ * Mean visibility-style score for a full landmark set (hands, pose).
+ * Same model-vs-geometry rule as the face mesh (`FACE_VISIBILITY_MODEL_TRUST_EPS`).
+ */
+function meanLandmarkSetVisibility(landmarks: RawNormLm[] | null | undefined): number | null {
+  if (!landmarks || landmarks.length === 0) return null;
+  let visSum = 0;
+  let presentCount = 0;
+  for (const lm of landmarks) {
+    if (!lm || !isFiniteLandmarkXY(lm)) continue;
+    presentCount += 1;
+    const modelVis =
+      typeof lm.visibility === 'number' && Number.isFinite(lm.visibility) ? lm.visibility : 0;
+    const geom = geometricFaceFramingScore(lm.x!, lm.y!);
+    const v = modelVis > FACE_VISIBILITY_MODEL_TRUST_EPS ? modelVis : geom;
+    visSum += v;
+  }
+  if (presentCount === 0) return null;
+  const meshCoverage = presentCount / landmarks.length;
+  return (visSum / presentCount) * meshCoverage;
+}
+
+/**
+ * Torso-only pose anchors in MediaPipe Pose 33-pt layout.
+ * We intentionally exclude wrist/hand-adjacent indices so visible hands do not
+ * inflate `poseVisibilityMean` when body framing is poor.
+ */
+const POSE_UPPER_BODY_VISIBILITY_INDICES: readonly number[] = [11, 12, 23, 24];
+
+function meanLandmarkSubsetVisibility(
+  landmarks: RawNormLm[] | null | undefined,
+  indices: readonly number[],
+): number | null {
+  if (!landmarks || landmarks.length === 0 || indices.length === 0) return null;
+  let visSum = 0;
+  let presentCount = 0;
+  for (const idx of indices) {
+    if (idx < 0 || idx >= landmarks.length) continue;
+    const lm = landmarks[idx];
+    if (!lm || !isFiniteLandmarkXY(lm)) continue;
+    presentCount += 1;
+    const modelVis =
+      typeof lm.visibility === 'number' && Number.isFinite(lm.visibility) ? lm.visibility : 0;
+    const geom = geometricFaceFramingScore(lm.x!, lm.y!);
+    const v = modelVis > FACE_VISIBILITY_MODEL_TRUST_EPS ? modelVis : geom;
+    visSum += v;
+  }
+  if (presentCount === 0) return null;
+  const meshCoverage = presentCount / indices.length;
+  return (visSum / presentCount) * meshCoverage;
+}
+
 export class WebMediaPipeLandmarkBackend implements LandmarkExtractionBackend {
   private faceLandmarker: FaceLandmarker | null = null;
   private handLandmarker: HandLandmarker | null = null;
@@ -135,28 +221,66 @@ export class WebMediaPipeLandmarkBackend implements LandmarkExtractionBackend {
       return null;
     }
 
-    const faceLandmarksRaw = faceResult.faceLandmarks?.[0];
-    const faceLandmarks = faceLandmarksRaw
-      ? FACE_LANDMARK_INDICES.map((idx) => {
-          const lm = faceLandmarksRaw[idx];
-          return lm ? [lm.x, lm.y, lm.z] : [0, 0, 0];
-        })
-      : null;
+    // `[]` is truthy in JS — guard length so we do not fabricate an all-zero mesh and visibility 0.
+    const rawFace = faceResult.faceLandmarks?.[0];
+    const faceLandmarksRaw =
+      Array.isArray(rawFace) && rawFace.length > 0 ? (rawFace as { x: number; y: number; z: number; visibility?: number }[]) : null;
 
-    let leftHandLandmarks: number[][] | null = null;
-    let rightHandLandmarks: number[][] | null = null;
-    if (handResult.landmarks && handResult.handedness) {
-      for (let i = 0; i < handResult.landmarks.length; i++) {
-        const label = handResult.handedness[i]?.[0]?.categoryName?.toLowerCase();
-        const lm = toLandmarkArray(handResult.landmarks[i]);
-        if (label === 'left' && !leftHandLandmarks) leftHandLandmarks = lm;
-        else if (label === 'right' && !rightHandLandmarks) rightHandLandmarks = lm;
+    let faceLandmarks: number[][] | null = null;
+    let faceMeanVisibility: number | null = null;
+    if (faceLandmarksRaw) {
+      let visSum = 0;
+      let presentCount = 0;
+      faceLandmarks = FACE_LANDMARK_INDICES.map((idx) => {
+        const lm = faceLandmarksRaw[idx];
+        if (lm && isFiniteLandmarkXY(lm)) {
+          presentCount += 1;
+          const modelVis =
+            typeof lm.visibility === 'number' && Number.isFinite(lm.visibility) ? lm.visibility : 0;
+          const geom = geometricFaceFramingScore(lm.x, lm.y);
+          const v = modelVis > FACE_VISIBILITY_MODEL_TRUST_EPS ? modelVis : geom;
+          visSum += v;
+          const z = typeof lm.z === 'number' && Number.isFinite(lm.z) ? lm.z : 0;
+          return [lm.x, lm.y, z];
+        }
+        return [0, 0, 0];
+      });
+
+      if (presentCount === 0) {
+        faceLandmarks = null;
+        faceMeanVisibility = null;
+      } else {
+        const meshCoverage = presentCount / FACE_LANDMARK_INDICES.length;
+        faceMeanVisibility = (visSum / presentCount) * meshCoverage;
       }
     }
 
-    const poseLandmarks = poseResult.landmarks?.[0]
-      ? toLandmarkArray(poseResult.landmarks[0])
-      : null;
+    let leftHandLandmarks: number[][] | null = null;
+    let rightHandLandmarks: number[][] | null = null;
+    let leftHandVisibilityMean: number | null = null;
+    let rightHandVisibilityMean: number | null = null;
+    if (handResult.landmarks && handResult.handedness) {
+      for (let i = 0; i < handResult.landmarks.length; i++) {
+        const label = handResult.handedness[i]?.[0]?.categoryName?.toLowerCase();
+        const rawHand = handResult.landmarks[i] as RawNormLm[] | undefined;
+        const lm = toLandmarkArray(rawHand as Array<{ x: number; y: number; z: number }> | undefined);
+        const meanVis = meanLandmarkSetVisibility(rawHand);
+        if (label === 'left' && !leftHandLandmarks) {
+          leftHandLandmarks = lm;
+          leftHandVisibilityMean = meanVis;
+        } else if (label === 'right' && !rightHandLandmarks) {
+          rightHandLandmarks = lm;
+          rightHandVisibilityMean = meanVis;
+        }
+      }
+    }
+
+    const rawPose = poseResult.landmarks?.[0] as RawNormLm[] | undefined;
+    const poseLandmarks =
+      Array.isArray(rawPose) && rawPose.length > 0
+        ? toLandmarkArray(rawPose as Array<{ x: number; y: number; z: number }>)
+        : null;
+    const poseVisibilityMean = meanLandmarkSubsetVisibility(rawPose, POSE_UPPER_BODY_VISIBILITY_INDICES);
 
     if (!faceLandmarks && !leftHandLandmarks && !rightHandLandmarks && !poseLandmarks) {
       return null;
@@ -165,10 +289,14 @@ export class WebMediaPipeLandmarkBackend implements LandmarkExtractionBackend {
     return {
       sessionId: '',
       timestampMs: ts,
+      faceMeanVisibility,
       faceLandmarks,
       leftHandLandmarks,
       rightHandLandmarks,
       poseLandmarks,
+      leftHandVisibilityMean,
+      rightHandVisibilityMean,
+      poseVisibilityMean,
     };
   }
 

--- a/sozia/client/pipeline/video/signVisibilityBanner.ts
+++ b/sozia/client/pipeline/video/signVisibilityBanner.ts
@@ -1,0 +1,17 @@
+/**
+ * SIGN degraded copy after sustained low visibility:
+ * - Both hands detected but low scores, or both hands not detected while pose exists → hands path
+ * - Upper body only → upper-body alert
+ * - Any hands issue together with pose issue → one general framing alert
+ */
+export function signVisibilityBannerKeys(
+  handsAnyBad: boolean,
+  poseBad: boolean,
+  handsBothMissing: boolean,
+): string[] {
+  const handsIssue = handsAnyBad || handsBothMissing;
+  if (handsIssue && poseBad) return ['health.signLowSigningFraming'];
+  if (handsIssue) return ['health.signLowHands'];
+  if (poseBad) return ['health.signLowUpperBody'];
+  return ['health.signLowSigningVisibility'];
+}

--- a/sozia/client/ui/components/NativeCameraView/helpers.ts
+++ b/sozia/client/ui/components/NativeCameraView/helpers.ts
@@ -43,14 +43,31 @@ export function normalizeLandmarkFrame(raw: unknown): LandmarkFrame | null {
     return null;
   }
 
+  const faceMeanVisibility = readOptionalFaceMeanVisibility(obj['faceMeanVisibility']);
+  const leftHandVisibilityMean = readOptionalFaceMeanVisibility(obj['leftHandVisibilityMean']);
+  const rightHandVisibilityMean = readOptionalFaceMeanVisibility(obj['rightHandVisibilityMean']);
+  const poseVisibilityMean = readOptionalFaceMeanVisibility(obj['poseVisibilityMean']);
+
   return {
     sessionId: obj['sessionId'] as string,
     timestampMs: obj['timestampMs'] as number,
+    ...(faceMeanVisibility !== undefined ? { faceMeanVisibility } : {}),
+    ...(leftHandVisibilityMean !== undefined ? { leftHandVisibilityMean } : {}),
+    ...(rightHandVisibilityMean !== undefined ? { rightHandVisibilityMean } : {}),
+    ...(poseVisibilityMean !== undefined ? { poseVisibilityMean } : {}),
     faceLandmarks,
     leftHandLandmarks,
     rightHandLandmarks,
     poseLandmarks,
   };
+}
+
+/** Undefined if absent or invalid; null if JSON null; otherwise [0, 1]. */
+function readOptionalFaceMeanVisibility(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) return undefined;
+  return value;
 }
 
 /**

--- a/sozia/client/ui/components/StatusBar/helpers.ts
+++ b/sozia/client/ui/components/StatusBar/helpers.ts
@@ -29,7 +29,7 @@ function degradedMessage(healthReports: PipelineHealth[], activePath: ModalityPa
   ) {
     return 'health.keepFaceInCamera';
   }
-  if (video && video.faceDetected === false) return 'health.noFaceDetected';
+  if (video && video.faceDetected === false) return 'health.keepFaceInCamera';
   if (audio && audio.snr !== null && audio.snr < LOW_SNR_THRESHOLD) return 'health.lowSignalQuality';
 
   return 'health.degraded';

--- a/sozia/client/ui/components/StatusBar/helpers.ts
+++ b/sozia/client/ui/components/StatusBar/helpers.ts
@@ -13,12 +13,44 @@ export interface Banner {
   showSpinner: boolean;
 }
 
+/** SPEECH: rolling `available` flips when >50% of frames lack landmarks; use fps + faceFrameRatio to avoid mislabeling that as a blocked camera. */
+function speechVideoLooksLive(video: PipelineHealth): boolean {
+  if ((video.fps ?? 0) < 2) return false;
+  const r = video.faceFrameRatio;
+  return typeof r === 'number' && Number.isFinite(r);
+}
+
 function degradedMessage(healthReports: PipelineHealth[], activePath: ModalityPath | null): string {
   const audio = healthReports.find((r) => r.pipeline === 'audio');
   const video = healthReports.find((r) => r.pipeline === 'video');
 
   if (audio && !audio.available) return 'health.microphoneUnavailable';
-  if (video && !video.available) return 'health.cameraObstructed';
+
+  const treatVideoUnavailableAsObstructed =
+    video &&
+    !video.available &&
+    !(activePath === ModalityPath.SPEECH && speechVideoLooksLive(video));
+
+  if (treatVideoUnavailableAsObstructed) return 'health.cameraObstructed';
+
+  // SPEECH: video "unavailable" by rolling null-landmark rule but stream still live → face UX, not lens.
+  if (
+    activePath === ModalityPath.SPEECH &&
+    video &&
+    !video.available &&
+    speechVideoLooksLive(video)
+  ) {
+    if (video.faceDetected === false) return 'health.noFaceDetected';
+    if (
+      typeof video.faceFrameRatio === 'number' &&
+      Number.isFinite(video.faceFrameRatio) &&
+      video.faceFrameRatio < SPEECH_FACE_IN_FRAME_MIN_RATIO
+    ) {
+      return 'health.keepFaceInCamera';
+    }
+  }
+
+  if (video && video.faceDetected === false) return 'health.noFaceDetected';
   if (
     activePath === ModalityPath.SPEECH &&
     video &&
@@ -29,7 +61,6 @@ function degradedMessage(healthReports: PipelineHealth[], activePath: ModalityPa
   ) {
     return 'health.keepFaceInCamera';
   }
-  if (video && video.faceDetected === false) return 'health.keepFaceInCamera';
   if (audio && audio.snr !== null && audio.snr < LOW_SNR_THRESHOLD) return 'health.lowSignalQuality';
 
   return 'health.degraded';

--- a/sozia/client/ui/components/StatusBar/helpers.ts
+++ b/sozia/client/ui/components/StatusBar/helpers.ts
@@ -1,28 +1,56 @@
-import { SessionState, type PipelineHealth } from '@common/models';
+import { ModalityPath, SessionState, type PipelineHealth } from '@common/models';
+import { SPEECH_FACE_IN_FRAME_MIN_RATIO } from '@/ui/healthThresholds';
 
 const LOW_SNR_THRESHOLD = 5;
 
 export interface Banner {
   messageKey: string;
+  /** When set (e.g. SIGN visibility), each key is translated and joined for display. */
+  messageKeys?: string[];
   bg: string;
   text: string;
   showRestart: boolean;
   showSpinner: boolean;
 }
 
-function degradedMessage(healthReports: PipelineHealth[]): string {
+function degradedMessage(healthReports: PipelineHealth[], activePath: ModalityPath | null): string {
   const audio = healthReports.find((r) => r.pipeline === 'audio');
   const video = healthReports.find((r) => r.pipeline === 'video');
 
   if (audio && !audio.available) return 'health.microphoneUnavailable';
   if (video && !video.available) return 'health.cameraObstructed';
+  if (
+    activePath === ModalityPath.SPEECH &&
+    video &&
+    video.available &&
+    typeof video.faceFrameRatio === 'number' &&
+    Number.isFinite(video.faceFrameRatio) &&
+    video.faceFrameRatio < SPEECH_FACE_IN_FRAME_MIN_RATIO
+  ) {
+    return 'health.keepFaceInCamera';
+  }
   if (video && video.faceDetected === false) return 'health.noFaceDetected';
   if (audio && audio.snr !== null && audio.snr < LOW_SNR_THRESHOLD) return 'health.lowSignalQuality';
 
   return 'health.degraded';
 }
 
-export function getStatusBanner(state: SessionState, healthReports: PipelineHealth[]): Banner | null {
+function signVisibilityKeysFromVideo(
+  healthReports: PipelineHealth[],
+  activePath: ModalityPath | null,
+): string[] | null {
+  if (activePath !== ModalityPath.SIGN) return null;
+  const video = healthReports.find((r) => r.pipeline === 'video');
+  const keys = video?.signVisibilityMessageKeys;
+  if (!video?.available || !Array.isArray(keys) || keys.length === 0) return null;
+  return keys;
+}
+
+export function getStatusBanner(
+  state: SessionState,
+  healthReports: PipelineHealth[],
+  activePath: ModalityPath | null = null,
+): Banner | null {
   switch (state) {
     case SessionState.RUNNING:
       return {
@@ -48,14 +76,17 @@ export function getStatusBanner(state: SessionState, healthReports: PipelineHeal
         showRestart: false,
         showSpinner: false,
       };
-    case SessionState.DEGRADED:
+    case SessionState.DEGRADED: {
+      const signKeys = signVisibilityKeysFromVideo(healthReports, activePath);
       return {
-        messageKey: degradedMessage(healthReports),
+        messageKey: signKeys?.length ? signKeys[0] : degradedMessage(healthReports, activePath),
+        messageKeys: signKeys ?? undefined,
         bg: 'bg-orange-500/80',
         text: 'text-white',
         showRestart: false,
         showSpinner: false,
       };
+    }
     case SessionState.ERROR:
       return {
         messageKey: 'health.sessionError',

--- a/sozia/client/ui/components/StatusBar/index.tsx
+++ b/sozia/client/ui/components/StatusBar/index.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
 import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
 
-import type { PipelineHealth, SessionState } from '@common/models';
+import type { ModalityPath, PipelineHealth, SessionState } from '@common/models';
 import { useLanguage } from '../../context/LanguageContext';
 import { getStatusBanner } from './helpers';
 
 interface StatusBarProps {
   state: SessionState;
   healthReports: PipelineHealth[];
+  activePath: ModalityPath | null;
   onRestart: () => void;
 }
 
-export function StatusBar({ state, healthReports, onRestart }: StatusBarProps) {
+export function StatusBar({ state, healthReports, activePath, onRestart }: StatusBarProps) {
   const { t } = useLanguage();
-  const banner = getStatusBanner(state, healthReports);
+  const banner = getStatusBanner(state, healthReports, activePath);
 
   if (!banner) return null;
 
@@ -25,7 +26,9 @@ export function StatusBar({ state, healthReports, onRestart }: StatusBarProps) {
         <ActivityIndicator size="small" color="#ffffff" />
       )}
       <Text className={`text-xs font-semibold ${banner.text}`}>
-        {t(banner.messageKey)}
+        {(banner.messageKeys?.length ? banner.messageKeys : [banner.messageKey])
+          .map((k) => t(k))
+          .join(' · ')}
       </Text>
       {banner.showRestart && (
         <TouchableOpacity

--- a/sozia/client/ui/controller/SessionController.tsx
+++ b/sozia/client/ui/controller/SessionController.tsx
@@ -144,6 +144,7 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
         setState,
         getHealthReports: () => healthReportsRef.current,
         setHealthReports,
+        getModalityPath: () => activePathRef.current,
       }),
     []
   );

--- a/sozia/client/ui/controller/sessionActions.ts
+++ b/sozia/client/ui/controller/sessionActions.ts
@@ -1,10 +1,12 @@
-import { SessionState, type PipelineHealth } from '@common/models';
+import { ModalityPath, SessionState, type PipelineHealth } from '@common/models';
+import { SPEECH_FACE_IN_FRAME_MIN_RATIO } from '@/ui/healthThresholds';
 
 export interface SessionStateAccessor {
   getState: () => SessionState;
   setState: (state: SessionState) => void;
   getHealthReports: () => PipelineHealth[];
   setHealthReports: (reports: PipelineHealth[]) => void;
+  getModalityPath: () => ModalityPath | null;
 }
 
 export interface SessionActions {
@@ -12,7 +14,30 @@ export interface SessionActions {
   onConnectionLost: () => void;
 }
 
+function sameSignVisibilityKeys(a: PipelineHealth, b: PipelineHealth): boolean {
+  const aa = a.signVisibilityMessageKeys ?? null;
+  const bb = b.signVisibilityMessageKeys ?? null;
+  if (aa === null && bb === null) return true;
+  if (aa === null || bb === null || aa.length !== bb.length) return false;
+  return aa.every((v, i) => v === bb[i]);
+}
+
 export function buildSessionActions(accessor: SessionStateAccessor): SessionActions {
+  function speechFaceBelowThreshold(reports: PipelineHealth[]): boolean {
+    if (accessor.getModalityPath() !== ModalityPath.SPEECH) return false;
+    const video = reports.find((r) => r.pipeline === 'video');
+    if (!video?.available) return false;
+    const r = video.faceFrameRatio;
+    return typeof r === 'number' && Number.isFinite(r) && r < SPEECH_FACE_IN_FRAME_MIN_RATIO;
+  }
+
+  function signVisibilitySustainedLow(reports: PipelineHealth[]): boolean {
+    if (accessor.getModalityPath() !== ModalityPath.SIGN) return false;
+    const video = reports.find((r) => r.pipeline === 'video');
+    if (!video?.available) return false;
+    return video.signVisibilitySustainedLow === true;
+  }
+
   function onPipelineHealthChanged(health: PipelineHealth): void {
     const current = accessor.getHealthReports();
     const idx = current.findIndex((r) => r.pipeline === health.pipeline);
@@ -23,7 +48,10 @@ export function buildSessionActions(accessor: SessionStateAccessor): SessionActi
       existing != null &&
       existing.available === health.available &&
       existing.fps === health.fps &&
-      existing.faceDetected === health.faceDetected
+      existing.faceDetected === health.faceDetected &&
+      (existing.faceFrameRatio ?? null) === (health.faceFrameRatio ?? null) &&
+      (existing.signVisibilitySustainedLow ?? false) === (health.signVisibilitySustainedLow ?? false) &&
+      sameSignVisibilityKeys(existing, health)
     ) return;
 
     const updated = idx >= 0
@@ -35,9 +63,13 @@ export function buildSessionActions(accessor: SessionStateAccessor): SessionActi
     if (state === SessionState.ERROR || state === SessionState.IDLE) return;
 
     const hasUnavailable = updated.some((r) => !r.available);
-    if (hasUnavailable && state === SessionState.RUNNING) {
+    const speechLowFace = speechFaceBelowThreshold(updated);
+    const signLowVis = signVisibilitySustainedLow(updated);
+    const shouldDegrade = hasUnavailable || speechLowFace || signLowVis;
+
+    if (shouldDegrade && state === SessionState.RUNNING) {
       accessor.setState(SessionState.DEGRADED);
-    } else if (!hasUnavailable && state === SessionState.DEGRADED) {
+    } else if (!shouldDegrade && state === SessionState.DEGRADED) {
       accessor.setState(SessionState.RUNNING);
     }
   }

--- a/sozia/client/ui/healthThresholds.ts
+++ b/sozia/client/ui/healthThresholds.ts
@@ -1,0 +1,14 @@
+/**
+ * Rolling fraction of recent video samples that must include a face mesh
+ * (SPEECH / lip-reading) to avoid client-side DEGRADED.
+ */
+export const SPEECH_FACE_IN_FRAME_MIN_RATIO = 0.5;
+
+/** Min hand visibility [0,1] for SIGN (both hands must be below this to count as “hands bad”). */
+export const SIGN_HAND_VISIBILITY_MIN = 0.7;
+
+/** Min upper-body (pose subset) visibility [0,1] for SIGN; looser than hands. */
+export const SIGN_POSE_VISIBILITY_MIN = 0.7;
+
+/** Hands-both-bad OR pose-bad must hold continuously this long (SIGN). */
+export const SIGN_VISIBILITY_LOW_MIN_MS = 1500;

--- a/sozia/client/ui/i18n/locales/en.json
+++ b/sozia/client/ui/i18n/locales/en.json
@@ -152,6 +152,11 @@
       "microphoneUnavailable": "Microphone unavailable",
       "lowSignalQuality": "Low signal quality",
       "noFaceDetected": "No face detected",
+      "keepFaceInCamera": "Please keep your face in the camera frame",
+      "signLowHands": "Hands are hard to see — keep them in the frame",
+      "signLowUpperBody": "Upper body is hard to see — step back or adjust the camera",
+      "signLowSigningFraming": "Hands and upper body are hard to see — step back, widen the shot, and improve lighting",
+      "signLowSigningVisibility": "Signing visibility is low — improve lighting and framing",
       "degraded": "Running in degraded mode",
       "restart": "Restart"
     },

--- a/sozia/client/ui/i18n/locales/tr.json
+++ b/sozia/client/ui/i18n/locales/tr.json
@@ -152,6 +152,11 @@
       "microphoneUnavailable": "Mikrofon kullanılamıyor",
       "lowSignalQuality": "Düşük sinyal kalitesi",
       "noFaceDetected": "Yüz algılanmadı",
+      "keepFaceInCamera": "Lütfen yüzünüzü kamera kadrajında tutun",
+      "signLowHands": "Eller zor görünüyor — kadrajda tutun",
+      "signLowUpperBody": "Üst vücut zor görünüyor — uzaklaşın veya kamerayı ayarlayın",
+      "signLowSigningFraming": "Eller ve üst vücut zor görünüyor — uzaklaşın, kadrajı genişletin, ışığı iyileştirin",
+      "signLowSigningVisibility": "İşaret görünürlüğü düşük — ışık ve kadrajı iyileştirin",
       "degraded": "Düşük performanslı modda çalışıyor",
       "restart": "Yeniden Başlat"
     },

--- a/sozia/client/ui/screens/LiveTranslationScreen.tsx
+++ b/sozia/client/ui/screens/LiveTranslationScreen.tsx
@@ -82,6 +82,7 @@ export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
           <StatusBar
             state={state}
             healthReports={healthReports}
+            activePath={activePath}
             onRestart={() => {
               void restartSession();
             }}

--- a/sozia/common/models/index.ts
+++ b/sozia/common/models/index.ts
@@ -43,6 +43,23 @@ export interface PipelineHealth {
   snr: number | null;
   /** Whether a face is currently detected. Video pipeline only; null for audio. */
   faceDetected: boolean | null;
+  /**
+   * Video only: rolling fraction of recent samples (same window as `available`)
+   * where `faceLandmarks` was non-null. null if no samples yet. Client-only for
+   * SPEECH lip UX; not sent on the wire.
+   */
+  faceFrameRatio?: number | null;
+  /**
+   * Video, SIGN: true when (any detected hand below `SIGN_HAND_VISIBILITY_MIN`) or (pose below
+   * `SIGN_POSE_VISIBILITY_MIN`) or (pose tracked but neither hand detected), continuously
+   * for ≥ `SIGN_VISIBILITY_LOW_MIN_MS`. Client-only; not on wire.
+   */
+  signVisibilitySustainedLow?: boolean;
+  /**
+   * Video, SIGN: i18n keys for degraded copy (hands-only, upper-body-only, or combined general).
+   * Set when sustained. Client-only; not on wire.
+   */
+  signVisibilityMessageKeys?: string[] | null;
   /** Milliseconds since session start. ≥ 0. */
   lastUpdatedMs: number;
 }
@@ -53,6 +70,14 @@ export interface LandmarkFrame {
   sessionId: string;
   /** Milliseconds since session start. ≥ 0, monotonically increasing within a session. */
   timestampMs: number;
+  /**
+   * [0, 1] face framing / confidence proxy over the 83-point subset (mean per landmark).
+   * Web: MediaPipe Face Landmarker usually leaves `visibility` at 0, so we use that when
+   * non-zero; otherwise a geometric score from normalized x/y (in-frame vs clipped edges).
+   * Missing mesh indices count as 0. null when no face mesh was detected this frame.
+   * Client-only: not serialized to the server (`FeatureSerializer` strips it).
+   */
+  faceMeanVisibility?: number | null;
   /** 83 linguistically-relevant face points, each [x, y, z] normalised to [0.0, 1.0]. null if not detected. */
   faceLandmarks: number[][] | null;
   /** 21 points, each [x, y, z]. null if not detected. */
@@ -61,6 +86,18 @@ export interface LandmarkFrame {
   rightHandLandmarks: number[][] | null;
   /** 33 points, each [x, y, z]. null if not detected. */
   poseLandmarks: number[][] | null;
+  /**
+   * Mean visibility-style score [0,1] for hands this tick (web: MediaPipe visibility or
+   * geometric framing). Client-only; not serialized to server.
+   */
+  leftHandVisibilityMean?: number | null;
+  rightHandVisibilityMean?: number | null;
+  /**
+   * Mean visibility-style score for pose (web: torso-only subset of MediaPipe Pose,
+   * indices 11,12,23,24 shoulders+hips to keep this signal independent from hand visibility).
+   * Client-only.
+   */
+  poseVisibilityMean?: number | null;
 }
 
 /** Timestamped chunk of preprocessed audio features (LLD §3.1.2). */


### PR DESCRIPTION
## What does this PR do?

- Adds client-side video health for the sign-language modality (ModalityPath.SIGN): when hand and/or upper-body visibility stays poor for a sustained window, the session moves to DEGRADED and the status bar shows a specific i18n message (hands only, upper body only, or a combined framing message).
- 
- On web, WebMediaPipeLandmarkBackend now exposes per-part visibility-style means (MediaPipe visibility when trusted, otherwise a geometric in-frame score). Pose uses a torso-only subset of MediaPipe pose indices (11, 12, 23, 24) so visible hands do not inflate the pose score when the torso is poorly framed.
- 
- VideoPipeline logs throttled face / pose / hands visibility lines for debugging. No server wire format changes — client-only fields remain omitted from FeatureSerializer landmark payloads as before.

## Which package(s) does it touch?

Which package(s) does it touch?
sozia-client (primary): video pipeline, health monitor, session actions, status bar, i18n, unit tests.
sozia/common (within this repo): optional fields on LandmarkFrame / PipelineHealth for client-only metrics (not sent on the wire).

## How to test

1. From repo root: npm run check (or npm test + npm run lint + npm run typecheck).
2. Web, start a session on sign language:

  - Hold a framing where torso/hips/shoulders are cropped or off-screen but hands are visible — after ~1.5s sustained bad pose          score, expect upper-body degraded copy (and/or combined message if hands are also bad).
  - Show one hand with mean visibility below SIGN_HAND_VISIBILITY_MIN — after sustained window, expect hands message.
  - With pose tracked but no hand meshes for ~1.5s, expect hands guidance (missing hands path).

3. Confirm SPEECH path still degrades on low faceFrameRatio as before (unchanged intent).
4. Optional: watch browser console for [VideoPipeline] visibility face= … pose= … once per second while running.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [ ] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally