### PR TITLE
feat(ui): stabilize web camera startup and switching flow

### DIFF
--- a/sozia/client/device/DeviceEnumerator.ts
+++ b/sozia/client/device/DeviceEnumerator.ts
@@ -55,7 +55,17 @@ export class ExpoDeviceEnumerator implements IDeviceEnumerator {
   private async _listWeb(): Promise<DeviceHandle[]> {
     const infos = await navigator.mediaDevices.enumerateDevices();
     const audioInputs = infos.filter((d) => d.kind === 'audioinput');
-    const videoInputs = infos.filter((d) => d.kind === 'videoinput');
+    const rawVideoInputs = infos.filter((d) => d.kind === 'videoinput');
+    // Keep all video inputs (including default/communications) so built-in
+    // laptop camera options are not hidden on browsers that expose them that way.
+    // Deduplicate by deviceId to avoid repeated aliases in UI.
+    const seen = new Set<string>();
+    const videoInputs = rawVideoInputs.filter((d, idx) => {
+      const id = d.deviceId || `fallback-videoinput-${idx}`;
+      if (seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
 
     const toHandle = (d: MediaDeviceInfo, index: number): DeviceHandle => ({
       deviceId: d.deviceId || `default-${d.kind}-${index}`,

--- a/sozia/client/device/DeviceManager.ts
+++ b/sozia/client/device/DeviceManager.ts
@@ -59,9 +59,7 @@ export class DeviceManager {
    * Throws with an actionable message if permission is denied.
    */
   async activateMicrophone(): Promise<void> {
-    if (__DEV__) console.log('[DeviceManager] activateMicrophone: requesting permission');
     const { granted } = await requestRecordingPermissionsAsync();
-    if (__DEV__) console.log('[DeviceManager] activateMicrophone: permission granted=', granted);
     if (!granted) {
       this.micAvailable = false;
       throw new Error(
@@ -79,11 +77,9 @@ export class DeviceManager {
    * Throws with an actionable message if permission is denied.
    */
   async activateCamera(): Promise<void> {
-    if (__DEV__) console.log('[DeviceManager] activateCamera: platform=', Platform.OS, 'selectedCameraId=', this.selectedCameraId);
     if (Platform.OS !== 'web') {
       const { Camera: VisionCamera } = require('react-native-vision-camera') as typeof import('react-native-vision-camera');
       const status = await VisionCamera.requestCameraPermission();
-      if (__DEV__) console.log('[DeviceManager] activateCamera(native): status=', status);
       if (status !== 'granted') {
         this.cameraAvailable = false;
         throw new Error(
@@ -102,24 +98,16 @@ export class DeviceManager {
         const preferredConstraint: MediaTrackConstraints | boolean = this.selectedCameraId
           ? { deviceId: { exact: this.selectedCameraId } }
           : true;
-        if (__DEV__) console.log('[DeviceManager] activateCamera(web): trying getUserMedia with constraint=', preferredConstraint);
         const stream = await mediaDevices.getUserMedia({ video: preferredConstraint, audio: false });
-        if (__DEV__) {
-          const track = stream.getVideoTracks()[0];
-          console.log('[DeviceManager] activateCamera(web): getUserMedia success; track label=', track?.label, 'settings=', track?.getSettings?.());
-        }
         stream.getTracks().forEach((t) => t.stop());
         this.cameraAvailable = true;
         return;
-      } catch (err) {
-        if (__DEV__) console.warn('[DeviceManager] activateCamera(web): getUserMedia failed', err);
+      } catch {
         // Fall through to Expo permission API check for a clearer denial signal.
       }
     }
 
-    if (__DEV__) console.log('[DeviceManager] activateCamera(web): falling back to Expo permission API');
     const { granted } = await ExpoCamera.requestCameraPermissionsAsync();
-    if (__DEV__) console.log('[DeviceManager] activateCamera(web): Expo permission granted=', granted);
     if (!granted) {
       this.cameraAvailable = false;
       throw new Error(
@@ -142,7 +130,6 @@ export class DeviceManager {
     micHandle?: RawAudioHandle,
     tx?: TransmissionManager,
   ): Promise<void> {
-    if (__DEV__) console.log('[DeviceManager] startAudioPipeline: micAvailable=', this.micAvailable, 'sessionId=', sessionId);
     if (!this.micAvailable) {
       throw new Error('Cannot start audio pipeline: microphone has not been activated.');
     }
@@ -150,7 +137,6 @@ export class DeviceManager {
       throw new Error('Cannot start audio pipeline: no IAudioPipeline configured.');
     }
     await this.audioPipeline.start(sessionId, micHandle ?? {}, tx);
-    if (__DEV__) console.log('[DeviceManager] startAudioPipeline: started');
   }
 
   /**
@@ -158,7 +144,6 @@ export class DeviceManager {
    * Requires `activateCamera()` to have been called first.
    */
   async startVideoPipeline(sessionId: string, cameraHandle?: RawMediaHandle, tx?: TransmissionManager): Promise<void> {
-    if (__DEV__) console.log('[DeviceManager] startVideoPipeline: cameraAvailable=', this.cameraAvailable, 'sessionId=', sessionId, 'hasGetFrame=', Boolean(cameraHandle?.getFrame));
     if (!this.cameraAvailable) {
       throw new Error('Cannot start video pipeline: camera has not been activated.');
     }
@@ -166,11 +151,9 @@ export class DeviceManager {
       throw new Error('Cannot start video pipeline: no IVideoPipeline configured.');
     }
     this.videoPipeline.start(sessionId, cameraHandle ?? {}, tx);
-    if (__DEV__) console.log('[DeviceManager] startVideoPipeline: started');
   }
 
   updateVideoCameraHandle(handle: RawMediaHandle): void {
-    if (__DEV__) console.log('[DeviceManager] updateVideoCameraHandle: hasGetFrame=', Boolean(handle?.getFrame));
     this.videoPipeline?.setCameraHandle(handle);
   }
 

--- a/sozia/client/device/DeviceManager.ts
+++ b/sozia/client/device/DeviceManager.ts
@@ -59,7 +59,9 @@ export class DeviceManager {
    * Throws with an actionable message if permission is denied.
    */
   async activateMicrophone(): Promise<void> {
+    if (__DEV__) console.log('[DeviceManager] activateMicrophone: requesting permission');
     const { granted } = await requestRecordingPermissionsAsync();
+    if (__DEV__) console.log('[DeviceManager] activateMicrophone: permission granted=', granted);
     if (!granted) {
       this.micAvailable = false;
       throw new Error(
@@ -77,9 +79,11 @@ export class DeviceManager {
    * Throws with an actionable message if permission is denied.
    */
   async activateCamera(): Promise<void> {
+    if (__DEV__) console.log('[DeviceManager] activateCamera: platform=', Platform.OS, 'selectedCameraId=', this.selectedCameraId);
     if (Platform.OS !== 'web') {
       const { Camera: VisionCamera } = require('react-native-vision-camera') as typeof import('react-native-vision-camera');
       const status = await VisionCamera.requestCameraPermission();
+      if (__DEV__) console.log('[DeviceManager] activateCamera(native): status=', status);
       if (status !== 'granted') {
         this.cameraAvailable = false;
         throw new Error(
@@ -89,7 +93,33 @@ export class DeviceManager {
       this.cameraAvailable = true;
       return;
     }
+    // On web, trust the browser camera API first. In practice this is the
+    // same permission gate used by the preview stream and is more reliable
+    // than Expo's permission shim for external webcams.
+    const mediaDevices = (globalThis as { navigator?: { mediaDevices?: MediaDevices } }).navigator?.mediaDevices;
+    if (mediaDevices?.getUserMedia) {
+      try {
+        const preferredConstraint: MediaTrackConstraints | boolean = this.selectedCameraId
+          ? { deviceId: { exact: this.selectedCameraId } }
+          : true;
+        if (__DEV__) console.log('[DeviceManager] activateCamera(web): trying getUserMedia with constraint=', preferredConstraint);
+        const stream = await mediaDevices.getUserMedia({ video: preferredConstraint, audio: false });
+        if (__DEV__) {
+          const track = stream.getVideoTracks()[0];
+          console.log('[DeviceManager] activateCamera(web): getUserMedia success; track label=', track?.label, 'settings=', track?.getSettings?.());
+        }
+        stream.getTracks().forEach((t) => t.stop());
+        this.cameraAvailable = true;
+        return;
+      } catch (err) {
+        if (__DEV__) console.warn('[DeviceManager] activateCamera(web): getUserMedia failed', err);
+        // Fall through to Expo permission API check for a clearer denial signal.
+      }
+    }
+
+    if (__DEV__) console.log('[DeviceManager] activateCamera(web): falling back to Expo permission API');
     const { granted } = await ExpoCamera.requestCameraPermissionsAsync();
+    if (__DEV__) console.log('[DeviceManager] activateCamera(web): Expo permission granted=', granted);
     if (!granted) {
       this.cameraAvailable = false;
       throw new Error(
@@ -112,6 +142,7 @@ export class DeviceManager {
     micHandle?: RawAudioHandle,
     tx?: TransmissionManager,
   ): Promise<void> {
+    if (__DEV__) console.log('[DeviceManager] startAudioPipeline: micAvailable=', this.micAvailable, 'sessionId=', sessionId);
     if (!this.micAvailable) {
       throw new Error('Cannot start audio pipeline: microphone has not been activated.');
     }
@@ -119,6 +150,7 @@ export class DeviceManager {
       throw new Error('Cannot start audio pipeline: no IAudioPipeline configured.');
     }
     await this.audioPipeline.start(sessionId, micHandle ?? {}, tx);
+    if (__DEV__) console.log('[DeviceManager] startAudioPipeline: started');
   }
 
   /**
@@ -126,6 +158,7 @@ export class DeviceManager {
    * Requires `activateCamera()` to have been called first.
    */
   async startVideoPipeline(sessionId: string, cameraHandle?: RawMediaHandle, tx?: TransmissionManager): Promise<void> {
+    if (__DEV__) console.log('[DeviceManager] startVideoPipeline: cameraAvailable=', this.cameraAvailable, 'sessionId=', sessionId, 'hasGetFrame=', Boolean(cameraHandle?.getFrame));
     if (!this.cameraAvailable) {
       throw new Error('Cannot start video pipeline: camera has not been activated.');
     }
@@ -133,10 +166,17 @@ export class DeviceManager {
       throw new Error('Cannot start video pipeline: no IVideoPipeline configured.');
     }
     this.videoPipeline.start(sessionId, cameraHandle ?? {}, tx);
+    if (__DEV__) console.log('[DeviceManager] startVideoPipeline: started');
   }
 
   updateVideoCameraHandle(handle: RawMediaHandle): void {
+    if (__DEV__) console.log('[DeviceManager] updateVideoCameraHandle: hasGetFrame=', Boolean(handle?.getFrame));
     this.videoPipeline?.setCameraHandle(handle);
+  }
+
+  /** Marks camera as available when preview is already live (web path). */
+  markCameraAvailable(): void {
+    this.cameraAvailable = true;
   }
 
   pauseAllPipelines(): void {

--- a/sozia/client/transmission/TransmissionManager.ts
+++ b/sozia/client/transmission/TransmissionManager.ts
@@ -124,6 +124,14 @@ export class TransmissionManager {
    * replies with a `ready` ack. Rejects after 10 s if no ack is received.
    */
   connect(sessionId: string, activePath: ModalityPath, apiKey: string): Promise<void> {
+    if (__DEV__) {
+      console.log('[TransmissionManager] connect: begin', {
+        sessionId,
+        activePath,
+        serverUrl: this.serverUrl,
+        apiKeyPresent: Boolean(apiKey),
+      });
+    }
     if (!isValidWsUrl(this.serverUrl)) {
       return Promise.reject(
         new Error(`TransmissionManager: invalid server URL "${this.serverUrl}"`)
@@ -234,19 +242,23 @@ export class TransmissionManager {
    */
   private _attachSocketHandlers(socket: WebSocketInstance): void {
     socket.onopen = () => {
+      if (__DEV__) console.log('[TransmissionManager] socket.onopen');
       this._sendRaw(this.serializer.sessionInit(this.sessionId!, this.activePath!, this.apiKey));
       // Buffer is flushed once the server sends "ready" (see _handleMessage).
     };
 
     socket.onmessage = (event) => {
+      if (__DEV__) console.log('[TransmissionManager] socket.onmessage', event.data);
       this._handleMessage(event.data);
     };
 
     socket.onclose = () => {
+      if (__DEV__) console.warn('[TransmissionManager] socket.onclose');
       this._handleClose();
     };
 
     socket.onerror = () => {
+      if (__DEV__) console.warn('[TransmissionManager] socket.onerror');
       // onclose follows onerror; handle reconnect there.
     };
   }
@@ -256,6 +268,7 @@ export class TransmissionManager {
   // ---------------------------------------------------------------------------
 
   private _sendRaw(data: string): void {
+    if (__DEV__) console.log('[TransmissionManager] sendRaw: readyState=', this.socket?.readyState ?? null, 'payload=', data);
     if (this.socket !== null && this.socket.readyState === WS_OPEN) {
       this.socket.send(data);
     } else {
@@ -343,6 +356,13 @@ export class TransmissionManager {
   // ---------------------------------------------------------------------------
 
   private _handleClose(): void {
+    if (__DEV__) {
+      console.warn('[TransmissionManager] handleClose', {
+        sessionId: this.sessionId,
+        reconnectAttempts: this.reconnectAttempts,
+        maxReconnectAttempts: this.maxReconnectAttempts,
+      });
+    }
     if (this.sessionId === null) return; // intentional disconnect — do not reconnect
 
     this.reconnectAttempts += 1;

--- a/sozia/client/transmission/TransmissionManager.ts
+++ b/sozia/client/transmission/TransmissionManager.ts
@@ -124,14 +124,6 @@ export class TransmissionManager {
    * replies with a `ready` ack. Rejects after 10 s if no ack is received.
    */
   connect(sessionId: string, activePath: ModalityPath, apiKey: string): Promise<void> {
-    if (__DEV__) {
-      console.log('[TransmissionManager] connect: begin', {
-        sessionId,
-        activePath,
-        serverUrl: this.serverUrl,
-        apiKeyPresent: Boolean(apiKey),
-      });
-    }
     if (!isValidWsUrl(this.serverUrl)) {
       return Promise.reject(
         new Error(`TransmissionManager: invalid server URL "${this.serverUrl}"`)
@@ -242,23 +234,19 @@ export class TransmissionManager {
    */
   private _attachSocketHandlers(socket: WebSocketInstance): void {
     socket.onopen = () => {
-      if (__DEV__) console.log('[TransmissionManager] socket.onopen');
       this._sendRaw(this.serializer.sessionInit(this.sessionId!, this.activePath!, this.apiKey));
       // Buffer is flushed once the server sends "ready" (see _handleMessage).
     };
 
     socket.onmessage = (event) => {
-      if (__DEV__) console.log('[TransmissionManager] socket.onmessage', event.data);
       this._handleMessage(event.data);
     };
 
     socket.onclose = () => {
-      if (__DEV__) console.warn('[TransmissionManager] socket.onclose');
       this._handleClose();
     };
 
     socket.onerror = () => {
-      if (__DEV__) console.warn('[TransmissionManager] socket.onerror');
       // onclose follows onerror; handle reconnect there.
     };
   }
@@ -268,7 +256,6 @@ export class TransmissionManager {
   // ---------------------------------------------------------------------------
 
   private _sendRaw(data: string): void {
-    if (__DEV__) console.log('[TransmissionManager] sendRaw: readyState=', this.socket?.readyState ?? null, 'payload=', data);
     if (this.socket !== null && this.socket.readyState === WS_OPEN) {
       this.socket.send(data);
     } else {
@@ -356,13 +343,6 @@ export class TransmissionManager {
   // ---------------------------------------------------------------------------
 
   private _handleClose(): void {
-    if (__DEV__) {
-      console.warn('[TransmissionManager] handleClose', {
-        sessionId: this.sessionId,
-        reconnectAttempts: this.reconnectAttempts,
-        maxReconnectAttempts: this.maxReconnectAttempts,
-      });
-    }
     if (this.sessionId === null) return; // intentional disconnect — do not reconnect
 
     this.reconnectAttempts += 1;

--- a/sozia/client/ui/components/WebCameraView/index.tsx
+++ b/sozia/client/ui/components/WebCameraView/index.tsx
@@ -1,0 +1,160 @@
+import React, { createElement, useEffect, useRef } from 'react';
+import { View, type StyleProp, ViewStyle } from 'react-native';
+
+export interface WebCameraViewProps {
+  /** When set, opens this `MediaDeviceInfo.deviceId` (web enumeration). Ignores `facing` for constraints. */
+  deviceId: string | null | undefined;
+  facing: 'front' | 'back';
+  /** When false, pauses the preview element (stream stays open). */
+  active: boolean;
+  mirror?: boolean;
+  style?: StyleProp<ViewStyle>;
+  /** Bump when the capture session changes so the stream is re-acquired. */
+  sessionKey?: string | null;
+  onVideoElement: (el: HTMLVideoElement | null) => void;
+  onCameraReady?: () => void;
+  onMountError?: (message: string, attemptedDeviceId: string | null | undefined) => void;
+}
+
+/**
+ * Web camera preview using `getUserMedia` with an optional concrete `deviceId`.
+ * expo-camera's web implementation only picks devices via `facingMode`, so
+ * external USB webcams chosen in device setup never apply without this path.
+ */
+export function WebCameraView({
+  deviceId,
+  facing,
+  active,
+  mirror = false,
+  style,
+  sessionKey,
+  onVideoElement,
+  onCameraReady,
+  onMountError,
+}: WebCameraViewProps): React.ReactElement {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const onVideoElementRef = useRef(onVideoElement);
+  const onCameraReadyRef = useRef(onCameraReady);
+  const onMountErrorRef = useRef(onMountError);
+
+  useEffect(() => {
+    onVideoElementRef.current = onVideoElement;
+    onCameraReadyRef.current = onCameraReady;
+    onMountErrorRef.current = onMountError;
+  });
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      onMountErrorRef.current?.('Camera API not available in this browser.', deviceId);
+      return;
+    }
+
+    let cancelled = false;
+    const video = videoRef.current;
+
+    const baselineConstraint: MediaTrackConstraints = {
+      width: { ideal: 640, max: 1280 },
+      height: { ideal: 480, max: 720 },
+      frameRate: { ideal: 30, max: 30 },
+    };
+    const facingConstraint: MediaTrackConstraints = {
+      ...baselineConstraint,
+      facingMode: facing === 'front' ? 'user' : 'environment',
+    };
+    const preferredConstraint: MediaTrackConstraints = deviceId
+      ? { deviceId: { exact: deviceId } }
+      : facingConstraint;
+
+    const attachStream = (stream: MediaStream): void => {
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        streamRef.current?.getTracks().forEach((t) => t.stop());
+        streamRef.current = stream;
+        if (video) {
+          video.srcObject = stream;
+          const notify = () => {
+            if (videoRef.current) onVideoElementRef.current(videoRef.current);
+            onCameraReadyRef.current?.();
+          };
+          video.addEventListener('loadedmetadata', notify, { once: true });
+          void video.play().then(notify).catch(() => {
+            notify();
+          });
+        }
+    };
+
+    const openCamera = async (): Promise<void> => {
+      try {
+        if (__DEV__) {
+          console.log('[WebCameraView] openCamera: request', {
+            deviceId,
+            facing,
+            preferredConstraint,
+          });
+        }
+        const preferred = await navigator.mediaDevices.getUserMedia({
+          audio: false,
+          video: preferredConstraint,
+        });
+        if (__DEV__) {
+          const track = preferred.getVideoTracks()[0];
+          console.log('[WebCameraView] openCamera: success', {
+            trackLabel: track?.label,
+            trackSettings: track?.getSettings?.(),
+          });
+        }
+        attachStream(preferred);
+        return;
+      } catch (err: unknown) {
+        if (cancelled) return;
+        if (__DEV__) console.warn('[WebCameraView] openCamera: failed', err);
+        const message = err instanceof Error ? err.message : String(err);
+        onMountErrorRef.current?.(message || 'Failed to open camera', deviceId);
+      }
+    };
+
+    void openCamera();
+
+    return () => {
+      cancelled = true;
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+      if (videoRef.current) {
+        videoRef.current.srcObject = null;
+      }
+      onVideoElementRef.current(null);
+    };
+  }, [deviceId, facing, sessionKey ?? '']);
+
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v) return;
+    if (active) {
+      void v.play().catch(() => {});
+    } else {
+      v.pause();
+    }
+  }, [active]);
+
+  const videoStyle: React.CSSProperties = {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    ...(mirror ? { transform: 'scaleX(-1)' } : {}),
+  };
+
+  return (
+    <View style={style}>
+      {createElement('video', {
+        ref: videoRef,
+        playsInline: true,
+        muted: true,
+        autoPlay: true,
+        style: videoStyle,
+      })}
+    </View>
+  );
+}

--- a/sozia/client/ui/components/WebCameraView/index.tsx
+++ b/sozia/client/ui/components/WebCameraView/index.tsx
@@ -88,29 +88,14 @@ export function WebCameraView({
 
     const openCamera = async (): Promise<void> => {
       try {
-        if (__DEV__) {
-          console.log('[WebCameraView] openCamera: request', {
-            deviceId,
-            facing,
-            preferredConstraint,
-          });
-        }
         const preferred = await navigator.mediaDevices.getUserMedia({
           audio: false,
           video: preferredConstraint,
         });
-        if (__DEV__) {
-          const track = preferred.getVideoTracks()[0];
-          console.log('[WebCameraView] openCamera: success', {
-            trackLabel: track?.label,
-            trackSettings: track?.getSettings?.(),
-          });
-        }
         attachStream(preferred);
         return;
       } catch (err: unknown) {
         if (cancelled) return;
-        if (__DEV__) console.warn('[WebCameraView] openCamera: failed', err);
         const message = err instanceof Error ? err.message : String(err);
         onMountErrorRef.current?.(message || 'Failed to open camera', deviceId);
       }

--- a/sozia/client/ui/components/WebCameraView/index.tsx
+++ b/sozia/client/ui/components/WebCameraView/index.tsx
@@ -63,7 +63,7 @@ export function WebCameraView({
       facingMode: facing === 'front' ? 'user' : 'environment',
     };
     const preferredConstraint: MediaTrackConstraints = deviceId
-      ? { deviceId: { exact: deviceId } }
+      ? { ...baselineConstraint, deviceId: { exact: deviceId } }
       : facingConstraint;
 
     const attachStream = (stream: MediaStream): void => {
@@ -87,17 +87,49 @@ export function WebCameraView({
     };
 
     const openCamera = async (): Promise<void> => {
-      try {
-        const preferred = await navigator.mediaDevices.getUserMedia({
-          audio: false,
-          video: preferredConstraint,
-        });
-        attachStream(preferred);
-        return;
-      } catch (err: unknown) {
-        if (cancelled) return;
-        const message = err instanceof Error ? err.message : String(err);
-        onMountErrorRef.current?.(message || 'Failed to open camera', deviceId);
+      // Release the existing stream before re-opening with a different device.
+      // Some browsers/device drivers reject opening another camera while one is active.
+      const previousStream = streamRef.current;
+      streamRef.current = null;
+      previousStream?.getTracks().forEach((t) => t.stop());
+      const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+      const isRetryableStartError = (err: unknown): boolean => {
+        const name = err instanceof Error ? err.name : '';
+        const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+        return (
+          name === 'NotReadableError' ||
+          name === 'AbortError' ||
+          message.includes('notreadableerror') ||
+          message.includes('could not start video source') ||
+          message.includes('starting videoinput failed')
+        );
+      };
+
+      if (previousStream) {
+        // Give the browser/driver a brief window to fully release the camera.
+        await sleep(120);
+      }
+
+      const maxAttempts = 3;
+      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        try {
+          const preferred = await navigator.mediaDevices.getUserMedia({
+            audio: false,
+            video: preferredConstraint,
+          });
+          attachStream(preferred);
+          return;
+        } catch (err: unknown) {
+          if (cancelled) return;
+          const retryable = isRetryableStartError(err);
+          if (retryable && attempt < maxAttempts) {
+            await sleep(180 * attempt);
+            continue;
+          }
+          const message = err instanceof Error ? err.message : String(err);
+          onMountErrorRef.current?.(message || 'Failed to open camera', deviceId);
+          return;
+        }
       }
     };
 

--- a/sozia/client/ui/components/WebCameraView/index.tsx
+++ b/sozia/client/ui/components/WebCameraView/index.tsx
@@ -103,16 +103,17 @@ export function WebCameraView({
 
     void openCamera();
 
+    const mountedVideo = video;
     return () => {
       cancelled = true;
       streamRef.current?.getTracks().forEach((t) => t.stop());
       streamRef.current = null;
-      if (videoRef.current) {
-        videoRef.current.srcObject = null;
+      if (mountedVideo) {
+        mountedVideo.srcObject = null;
       }
       onVideoElementRef.current(null);
     };
-  }, [deviceId, facing, sessionKey ?? '']);
+  }, [deviceId, facing, sessionKey]);
 
   useEffect(() => {
     const v = videoRef.current;

--- a/sozia/client/ui/controller/SessionController.tsx
+++ b/sozia/client/ui/controller/SessionController.tsx
@@ -119,14 +119,6 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
 
   const cameraVideoRef = useRef<HTMLVideoElement | null>(null);
   const setCameraVideoElement = useCallback((el: HTMLVideoElement | null) => {
-    if (__DEV__) {
-      console.log('[SessionController] setCameraVideoElement:', {
-        present: Boolean(el),
-        width: el?.videoWidth ?? 0,
-        height: el?.videoHeight ?? 0,
-        readyState: el?.readyState ?? -1,
-      });
-    }
     cameraVideoRef.current = el;
     if (el) {
       deviceManager.current.updateVideoCameraHandle({
@@ -183,9 +175,7 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
 
   const startSession = useCallback(async (path: ModalityPath) => {
     try {
-      if (__DEV__) console.log('[SessionController] startSession: begin', { path });
       if (configLoadPromise.current) {
-        if (__DEV__) console.log('[SessionController] startSession: waiting config load');
         await configLoadPromise.current;
       }
 
@@ -196,16 +186,13 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
       setState(SessionState.INITIALIZING);
       store.clear();
       const newSessionId = uuidV4();
-      if (__DEV__) console.log('[SessionController] startSession: sessionId=', newSessionId);
       setSessionId(newSessionId);
       setActivePath(path);
 
       const savedCameraId = config.current.get('selectedCameraId');
-      if (__DEV__) console.log('[SessionController] startSession: savedCameraId=', savedCameraId);
       if (savedCameraId) {
         try {
           const devices = await deviceManager.current.enumerateDevices();
-          if (__DEV__) console.log('[SessionController] startSession: enumerated devices=', devices);
           const cameraExists = devices.some(
             (d) => d.kind === 'videoinput' && d.deviceId === savedCameraId
           );
@@ -229,45 +216,23 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
           }
           await new Promise<void>((resolve) => setTimeout(resolve, 50));
         }
-        if (__DEV__) {
-          const preview = cameraVideoRef.current;
-          console.log('[SessionController] startSession: web preview probe', {
-            hasLiveWebPreview,
-            readyState: preview?.readyState ?? -1,
-            width: preview?.videoWidth ?? 0,
-            height: preview?.videoHeight ?? 0,
-          });
-        }
       }
 
       if (hasLiveWebPreview) {
-        if (__DEV__) {
-          console.log('[SessionController] startSession: using existing live web preview; skipping activateCamera');
-        }
         deviceManager.current.markCameraAvailable();
       } else {
         await deviceManager.current.activateCamera();
-        if (__DEV__) console.log('[SessionController] startSession: camera activated');
       }
 
       if (path === ModalityPath.SPEECH) {
         const savedMicId = config.current.get('selectedMicId');
-        if (__DEV__) console.log('[SessionController] startSession: savedMicId=', savedMicId);
         if (savedMicId) deviceManager.current.selectMicrophone(savedMicId);
         await deviceManager.current.activateMicrophone();
-        if (__DEV__) console.log('[SessionController] startSession: microphone activated');
       }
 
       const serverUrl = config.current.get('serverUrl') ?? 'ws://localhost:8080';
       const maxReconnectAttempts = config.current.get('maxReconnectAttempts') ?? 5;
       const apiKey = config.current.get('apiKey') ?? '';
-      if (__DEV__) {
-        console.log('[SessionController] startSession: transmission config', {
-          serverUrl,
-          maxReconnectAttempts,
-          apiKeyPresent: Boolean(apiKey),
-        });
-      }
 
       const handleSessionStatus = (msg: SessionStatusMessage) => {
         if (msg.state === SessionState.ERROR) {
@@ -281,51 +246,31 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
         actions.onConnectionLost,
         maxReconnectAttempts,
         handleSessionStatus,
-        (msg) => {
-          // Server-level error payloads are not always fatal (e.g. transient
-          // inference issues). Keep the session alive unless an actual
-          // disconnect happens or session_status reports ERROR.
-          if (__DEV__) {
-            console.warn('server error', msg.code, msg.message);
-          }
-        },
+        () => {},
       );
 
       const videoEl = cameraVideoRef.current;
-      if (__DEV__) {
-        console.log('[SessionController] startSession: current video element', {
-          present: Boolean(videoEl),
-          width: videoEl?.videoWidth ?? 0,
-          height: videoEl?.videoHeight ?? 0,
-          readyState: videoEl?.readyState ?? -1,
-        });
-      }
       const cameraHandle = videoEl
         ? { getFrame: () => ({ timestampMs: Date.now(), width: videoEl.videoWidth, height: videoEl.videoHeight, data: videoEl }) }
         : {};
 
       if (path === ModalityPath.SPEECH) {
-        if (__DEV__) console.log('[SessionController] startSession: starting audio+video pipelines');
         await deviceManager.current.startAudioPipeline(newSessionId, {}, transmissionManager.current);
         await deviceManager.current.startVideoPipeline(newSessionId, cameraHandle, transmissionManager.current);
       } else if (path === ModalityPath.SIGN) {
-        if (__DEV__) console.log('[SessionController] startSession: starting video pipeline only');
         await deviceManager.current.startVideoPipeline(newSessionId, cameraHandle, transmissionManager.current);
       }
 
       // Connect in the background — the send buffer holds frames produced
       // during the connection window. onConnectionLost handles failure.
       void transmissionManager.current.connect(newSessionId, path, apiKey).catch((err: unknown) => {
-        if (__DEV__) console.warn('[SessionController] startSession: connect failed', err);
         if (err instanceof DisconnectBeforeReadyError) return;
         actions.onConnectionLost();
       });
 
       deviceManager.current.pauseAllPipelines();
-      if (__DEV__) console.log('[SessionController] startSession: pipelines paused, state -> PAUSED');
       setState(SessionState.PAUSED);
     } catch (e) {
-      if (__DEV__) console.error('[SessionController] startSession: ERROR', e);
       setState(SessionState.ERROR);
       throw e;
     }

--- a/sozia/client/ui/controller/SessionController.tsx
+++ b/sozia/client/ui/controller/SessionController.tsx
@@ -77,6 +77,10 @@ function uuidV4(): string {
   );
 }
 
+function isLiveWebPreview(el: HTMLVideoElement | null): boolean {
+  return Boolean(el && el.readyState >= 2 && el.videoWidth > 0 && el.videoHeight > 0);
+}
+
 export function SessionControllerProvider({ children }: { children: React.ReactNode }) {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [state, setState] = useState<SessionState>(SessionState.IDLE);
@@ -97,12 +101,14 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
     ),
   );
   const config = useRef<IConfigurationManager>(new Configuration());
+  const configLoadPromise = useRef<Promise<void> | null>(null);
   const transmissionManager = useRef<TransmissionManager | null>(null);
 
   useEffect(() => {
-    void config.current.load().then(() => {
+    configLoadPromise.current = config.current.load().then(() => {
       deviceManager.current.setAudioVadSensitivity(config.current.get('vadSensitivity'));
     });
+    void configLoadPromise.current;
     if (!isNative) {
       // WebMediaPipeLandmarkBackend requires async model loading; native backend
       // is model-loaded by the JSI plugin on a background thread.
@@ -113,6 +119,14 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
 
   const cameraVideoRef = useRef<HTMLVideoElement | null>(null);
   const setCameraVideoElement = useCallback((el: HTMLVideoElement | null) => {
+    if (__DEV__) {
+      console.log('[SessionController] setCameraVideoElement:', {
+        present: Boolean(el),
+        width: el?.videoWidth ?? 0,
+        height: el?.videoHeight ?? 0,
+        readyState: el?.readyState ?? -1,
+      });
+    }
     cameraVideoRef.current = el;
     if (el) {
       deviceManager.current.updateVideoCameraHandle({
@@ -169,6 +183,12 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
 
   const startSession = useCallback(async (path: ModalityPath) => {
     try {
+      if (__DEV__) console.log('[SessionController] startSession: begin', { path });
+      if (configLoadPromise.current) {
+        if (__DEV__) console.log('[SessionController] startSession: waiting config load');
+        await configLoadPromise.current;
+      }
+
       deviceManager.current.stopAllPipelines();
       transmissionManager.current?.disconnect();
       transmissionManager.current = null;
@@ -176,22 +196,78 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
       setState(SessionState.INITIALIZING);
       store.clear();
       const newSessionId = uuidV4();
+      if (__DEV__) console.log('[SessionController] startSession: sessionId=', newSessionId);
       setSessionId(newSessionId);
       setActivePath(path);
 
       const savedCameraId = config.current.get('selectedCameraId');
-      if (savedCameraId) deviceManager.current.selectCamera(savedCameraId);
-      await deviceManager.current.activateCamera();
+      if (__DEV__) console.log('[SessionController] startSession: savedCameraId=', savedCameraId);
+      if (savedCameraId) {
+        try {
+          const devices = await deviceManager.current.enumerateDevices();
+          if (__DEV__) console.log('[SessionController] startSession: enumerated devices=', devices);
+          const cameraExists = devices.some(
+            (d) => d.kind === 'videoinput' && d.deviceId === savedCameraId
+          );
+          if (cameraExists) {
+            deviceManager.current.selectCamera(savedCameraId);
+          } else {
+            config.current.set('selectedCameraId', null);
+          }
+        } catch {
+          // Keep startup resilient if enumeration fails temporarily.
+          deviceManager.current.selectCamera(savedCameraId);
+        }
+      }
+      let hasLiveWebPreview = false;
+      if (Platform.OS === 'web') {
+        const timeoutAt = Date.now() + 1500;
+        while (Date.now() < timeoutAt) {
+          if (isLiveWebPreview(cameraVideoRef.current)) {
+            hasLiveWebPreview = true;
+            break;
+          }
+          await new Promise<void>((resolve) => setTimeout(resolve, 50));
+        }
+        if (__DEV__) {
+          const preview = cameraVideoRef.current;
+          console.log('[SessionController] startSession: web preview probe', {
+            hasLiveWebPreview,
+            readyState: preview?.readyState ?? -1,
+            width: preview?.videoWidth ?? 0,
+            height: preview?.videoHeight ?? 0,
+          });
+        }
+      }
+
+      if (hasLiveWebPreview) {
+        if (__DEV__) {
+          console.log('[SessionController] startSession: using existing live web preview; skipping activateCamera');
+        }
+        deviceManager.current.markCameraAvailable();
+      } else {
+        await deviceManager.current.activateCamera();
+        if (__DEV__) console.log('[SessionController] startSession: camera activated');
+      }
 
       if (path === ModalityPath.SPEECH) {
         const savedMicId = config.current.get('selectedMicId');
+        if (__DEV__) console.log('[SessionController] startSession: savedMicId=', savedMicId);
         if (savedMicId) deviceManager.current.selectMicrophone(savedMicId);
         await deviceManager.current.activateMicrophone();
+        if (__DEV__) console.log('[SessionController] startSession: microphone activated');
       }
 
       const serverUrl = config.current.get('serverUrl') ?? 'ws://localhost:8080';
       const maxReconnectAttempts = config.current.get('maxReconnectAttempts') ?? 5;
       const apiKey = config.current.get('apiKey') ?? '';
+      if (__DEV__) {
+        console.log('[SessionController] startSession: transmission config', {
+          serverUrl,
+          maxReconnectAttempts,
+          apiKeyPresent: Boolean(apiKey),
+        });
+      }
 
       const handleSessionStatus = (msg: SessionStatusMessage) => {
         if (msg.state === SessionState.ERROR) {
@@ -205,31 +281,51 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
         actions.onConnectionLost,
         maxReconnectAttempts,
         handleSessionStatus,
-        () => { actions.onConnectionLost(); },
+        (msg) => {
+          // Server-level error payloads are not always fatal (e.g. transient
+          // inference issues). Keep the session alive unless an actual
+          // disconnect happens or session_status reports ERROR.
+          if (__DEV__) {
+            console.warn('server error', msg.code, msg.message);
+          }
+        },
       );
 
       const videoEl = cameraVideoRef.current;
+      if (__DEV__) {
+        console.log('[SessionController] startSession: current video element', {
+          present: Boolean(videoEl),
+          width: videoEl?.videoWidth ?? 0,
+          height: videoEl?.videoHeight ?? 0,
+          readyState: videoEl?.readyState ?? -1,
+        });
+      }
       const cameraHandle = videoEl
         ? { getFrame: () => ({ timestampMs: Date.now(), width: videoEl.videoWidth, height: videoEl.videoHeight, data: videoEl }) }
         : {};
 
       if (path === ModalityPath.SPEECH) {
+        if (__DEV__) console.log('[SessionController] startSession: starting audio+video pipelines');
         await deviceManager.current.startAudioPipeline(newSessionId, {}, transmissionManager.current);
         await deviceManager.current.startVideoPipeline(newSessionId, cameraHandle, transmissionManager.current);
       } else if (path === ModalityPath.SIGN) {
+        if (__DEV__) console.log('[SessionController] startSession: starting video pipeline only');
         await deviceManager.current.startVideoPipeline(newSessionId, cameraHandle, transmissionManager.current);
       }
 
       // Connect in the background — the send buffer holds frames produced
       // during the connection window. onConnectionLost handles failure.
       void transmissionManager.current.connect(newSessionId, path, apiKey).catch((err: unknown) => {
+        if (__DEV__) console.warn('[SessionController] startSession: connect failed', err);
         if (err instanceof DisconnectBeforeReadyError) return;
         actions.onConnectionLost();
       });
 
       deviceManager.current.pauseAllPipelines();
+      if (__DEV__) console.log('[SessionController] startSession: pipelines paused, state -> PAUSED');
       setState(SessionState.PAUSED);
     } catch (e) {
+      if (__DEV__) console.error('[SessionController] startSession: ERROR', e);
       setState(SessionState.ERROR);
       throw e;
     }

--- a/sozia/client/ui/screens/DashboardScreen.tsx
+++ b/sozia/client/ui/screens/DashboardScreen.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ChevronDown, ChevronUp, CircleCheckBig, CircleHelp, CircleUser, Hand, House, Mic, Settings } from 'lucide-react-native';
+import { Camera as ExpoCamera } from 'expo-camera';
+import { getRecordingPermissionsAsync, requestRecordingPermissionsAsync } from 'expo-audio';
 import { useLanguage } from '../context/LanguageContext';
 
 import { ModalityPath, SessionState } from '@common/models';
@@ -20,7 +22,7 @@ export function DashboardScreen({
   onOpenHelp: () => void;
   onOpenProfile: () => void;
 }) {
-  const { state, activePath, startSession, enumerateDevices, selectMicrophone, selectCamera } = useSessionController();
+  const { state, activePath, startSession, enumerateDevices, selectMicrophone, selectCamera, config } = useSessionController();
   const { t } = useLanguage();
 
   const [activeTab, setActiveTab] = useState<'home' | 'help' | 'profile'>('home');
@@ -29,17 +31,40 @@ export function DashboardScreen({
   const [devices, setDevices] = useState<DeviceHandle[]>([]);
   const [selectedMicId, setSelectedMicId] = useState('');
   const [selectedCamId, setSelectedCamId] = useState('');
+  const [permissionsGranted, setPermissionsGranted] = useState<boolean>(false);
+  const [permissionsChecked, setPermissionsChecked] = useState<boolean>(false);
+  const [requestingPermissions, setRequestingPermissions] = useState<boolean>(false);
 
-  const canStart = state === SessionState.IDLE || state === SessionState.ERROR;
+  const canStart = (state === SessionState.IDLE || state === SessionState.ERROR) && permissionsGranted;
 
   const loadDevices = useCallback(async () => {
     const list = await enumerateDevices();
     setDevices(list);
-    const defaultMic = list.find((d) => d.kind === 'audioinput' && d.isDefault);
-    const defaultCam = list.find((d) => d.kind === 'videoinput' && d.isDefault);
-    if (defaultMic && !selectedMicId) setSelectedMicId(defaultMic.deviceId);
-    if (defaultCam && !selectedCamId) setSelectedCamId(defaultCam.deviceId);
-  }, [enumerateDevices, selectedMicId, selectedCamId]);
+
+    const savedMic = config.get('selectedMicId');
+    const savedCam = config.get('selectedCameraId');
+    const micInList = Boolean(savedMic && list.some((d) => d.kind === 'audioinput' && d.deviceId === savedMic));
+    const camInList = Boolean(savedCam && list.some((d) => d.kind === 'videoinput' && d.deviceId === savedCam));
+
+    const defaultMic =
+      list.find((d) => d.kind === 'audioinput' && d.isDefault) ?? list.find((d) => d.kind === 'audioinput');
+    const defaultCam =
+      list.find((d) => d.kind === 'videoinput' && d.isDefault) ?? list.find((d) => d.kind === 'videoinput');
+
+    const nextMicId = micInList ? savedMic! : (defaultMic?.deviceId ?? '');
+    const nextCamId = camInList ? savedCam! : (defaultCam?.deviceId ?? '');
+    setSelectedMicId(nextMicId);
+    setSelectedCamId(nextCamId);
+    if (nextMicId) selectMicrophone(nextMicId);
+    if (nextCamId) selectCamera(nextCamId);
+
+    if (!micInList && savedMic) {
+      config.set('selectedMicId', nextMicId || null);
+    }
+    if (!camInList && savedCam) {
+      config.set('selectedCameraId', nextCamId || null);
+    }
+  }, [enumerateDevices, config, selectMicrophone, selectCamera]);
 
   useEffect(() => {
     if (deviceSetupOpen && devices.length === 0) {
@@ -52,12 +77,50 @@ export function DashboardScreen({
 
   const tips = t('dashboard.tips', { returnObjects: true }) as string[];
 
+  const persistCurrentDeviceSelection = useCallback(() => {
+    config.set('selectedMicId', selectedMicId || null);
+    config.set('selectedCameraId', selectedCamId || null);
+    if (selectedMicId) selectMicrophone(selectedMicId);
+    if (selectedCamId) selectCamera(selectedCamId);
+  }, [config, selectedMicId, selectedCamId, selectMicrophone, selectCamera]);
+
+  const checkPermissions = useCallback(async () => {
+    try {
+      const cameraPermission = await ExpoCamera.getCameraPermissionsAsync();
+      const microphonePermission = await getRecordingPermissionsAsync();
+      setPermissionsGranted(Boolean(cameraPermission.granted && microphonePermission.granted));
+    } catch {
+      setPermissionsGranted(false);
+    } finally {
+      setPermissionsChecked(true);
+    }
+  }, []);
+
+  const requestPermissions = useCallback(async () => {
+    if (requestingPermissions) return;
+    setRequestingPermissions(true);
+    try {
+      const cameraPermission = await ExpoCamera.requestCameraPermissionsAsync();
+      const microphonePermission = await requestRecordingPermissionsAsync();
+      setPermissionsGranted(Boolean(cameraPermission.granted && microphonePermission.granted));
+    } catch {
+      setPermissionsGranted(false);
+    } finally {
+      setPermissionsChecked(true);
+      setRequestingPermissions(false);
+    }
+  }, [requestingPermissions]);
+
   useEffect(() => {
     const interval = setInterval(() => {
       setCurrentTipIndex((prev) => (prev + 1) % tips.length);
     }, 5000);
     return () => clearInterval(interval);
   }, [tips.length]);
+
+  useEffect(() => {
+    void checkPermissions();
+  }, [checkPermissions]);
 
   return (
     <SafeAreaView className="flex-1 w-full self-stretch bg-gradient-to-br from-[#2ECC71]/5 via-white dark:via-gray-900 to-[#2ECC71]/5">
@@ -80,6 +143,24 @@ export function DashboardScreen({
 
             {/* Device Setup */}
             <View className="px-6 pb-2">
+              {permissionsChecked && !permissionsGranted && (
+                <View className="mb-3 rounded-2xl border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-700 dark:bg-amber-950/40">
+                  <Text className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+                    Grant camera and microphone permission to start a session.
+                  </Text>
+                  <TouchableOpacity
+                    className={`mt-2 self-start rounded-xl px-3 py-2 ${requestingPermissions ? 'bg-amber-300/60' : 'bg-amber-300'}`}
+                    disabled={requestingPermissions}
+                    onPress={() => {
+                      void requestPermissions();
+                    }}
+                  >
+                    <Text className="text-xs font-bold text-amber-900">
+                      {requestingPermissions ? 'Requesting...' : 'Retry permission'}
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              )}
               <TouchableOpacity
                 className="flex-row items-center justify-between rounded-2xl border border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/60 px-4 py-3"
                 onPress={() => setDeviceSetupOpen((v) => !v)}
@@ -100,7 +181,11 @@ export function DashboardScreen({
                     <DeviceSelector
                       devices={mics}
                       selectedDeviceId={selectedMicId}
-                      onSelect={(id) => { setSelectedMicId(id); selectMicrophone(id); }}
+                      onSelect={(id) => {
+                        setSelectedMicId(id);
+                        selectMicrophone(id);
+                        config.set('selectedMicId', id);
+                      }}
                     />
                   </View>
                   <View>
@@ -110,7 +195,11 @@ export function DashboardScreen({
                     <DeviceSelector
                       devices={cameras}
                       selectedDeviceId={selectedCamId}
-                      onSelect={(id) => { setSelectedCamId(id); selectCamera(id); }}
+                      onSelect={(id) => {
+                        setSelectedCamId(id);
+                        selectCamera(id);
+                        config.set('selectedCameraId', id);
+                      }}
                     />
                   </View>
                 </View>
@@ -122,7 +211,12 @@ export function DashboardScreen({
                 className={`relative min-h-[180px] items-center justify-center rounded-[32px] bg-[#2ECC71] p-8 shadow-xl ${!canStart ? 'opacity-50' : ''}`}
                 disabled={!canStart}
                 onPress={async () => {
+                  if (!permissionsGranted) {
+                    void requestPermissions();
+                    return;
+                  }
                   if (!canStart) return;
+                  persistCurrentDeviceSelection();
                   onOpenLive();
                   try {
                     await startSession(ModalityPath.SPEECH);
@@ -142,7 +236,12 @@ export function DashboardScreen({
                 className={`relative min-h-[180px] items-center justify-center rounded-[32px] bg-[#1E8449] p-8 shadow-xl ${!canStart ? 'opacity-50' : ''}`}
                 disabled={!canStart}
                 onPress={async () => {
+                  if (!permissionsGranted) {
+                    void requestPermissions();
+                    return;
+                  }
                   if (!canStart) return;
+                  persistCurrentDeviceSelection();
                   onOpenLive();
                   try {
                     await startSession(ModalityPath.SIGN);

--- a/sozia/client/ui/screens/LiveTranslationScreen.tsx
+++ b/sozia/client/ui/screens/LiveTranslationScreen.tsx
@@ -1,9 +1,10 @@
-import { CameraView, type CameraType } from 'expo-camera';
-import React, { useEffect, useRef, useState } from 'react';
+import type { CameraType } from 'expo-camera';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Camera, ChevronDown, CircleX, Hand, Mic, PauseCircle, PlayCircle, Settings, SwitchCamera } from 'lucide-react-native';
 import { NativeCameraView } from '../components/NativeCameraView';
+import { WebCameraView } from '../components/WebCameraView';
 import { useLanguage } from '../context/LanguageContext';
 
 import { ModalityPath, SessionState } from '@common/models';
@@ -26,15 +27,26 @@ export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
     resumeSession,
     store,
     setCameraVideoElement,
-    setNativeLandmarks
+    setNativeLandmarks,
+    config,
+    enumerateDevices,
+    selectCamera,
   } = useSessionController();
   const cameraContainerRef = useRef<View>(null);
 
   const { t } = useLanguage();
+  const preferredCameraId = config.get('selectedCameraId');
+  const [webCameraIds, setWebCameraIds] = useState<string[]>([]);
+  const [activeWebCameraId, setActiveWebCameraId] = useState<string | null>(preferredCameraId);
   const [showSettings, setShowSettings] = useState(false);
   const [textSize, setTextSize] = useState(100);
   const [cameraFacing, setCameraFacing] = useState<CameraType>('front');
   const [cameraMountError, setCameraMountError] = useState<string | null>(null);
+  const [webMountAttempt, setWebMountAttempt] = useState(0);
+  const [requestingWebPermission, setRequestingWebPermission] = useState(false);
+  const [switchingAfterMountError, setSwitchingAfterMountError] = useState(false);
+  const [skipNextFailedCameraId, setSkipNextFailedCameraId] = useState<string | null>(null);
+  const mountErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const baseFontSize = (textSize / 100) * 30;
   const shouldShowLiveCamera = activePath === ModalityPath.SIGN || activePath === ModalityPath.SPEECH;
@@ -66,7 +78,131 @@ export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
 
   useEffect(() => {
     setCameraMountError(null);
-  }, [cameraFacing, activePath]);
+  }, [cameraFacing, activePath, preferredCameraId]);
+
+  useEffect(() => {
+    // New session: clear transient skip state.
+    setSkipNextFailedCameraId(null);
+    if (mountErrorTimerRef.current) {
+      clearTimeout(mountErrorTimerRef.current);
+      mountErrorTimerRef.current = null;
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    let cancelled = false;
+    void enumerateDevices()
+      .then((devices) => {
+        if (cancelled) return;
+        const ids = devices
+          .filter((d) => d.kind === 'videoinput')
+          .map((d) => d.deviceId)
+          .filter((id) => id.length > 0);
+        setWebCameraIds(ids);
+        const preferred = config.get('selectedCameraId');
+        const nextId =
+          preferred && ids.includes(preferred)
+            ? preferred
+            : (ids[0] ?? null);
+        setActiveWebCameraId(nextId);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [enumerateDevices, config, activePath]);
+
+  const switchCamera = async () => {
+    if (!shouldShowLiveCamera) return;
+    if (Platform.OS !== 'web') {
+      setCameraFacing((current) => (current === 'front' ? 'back' : 'front'));
+      return;
+    }
+
+    let ids = webCameraIds;
+    try {
+      const devices = await enumerateDevices();
+      ids = devices
+        .filter((d) => d.kind === 'videoinput')
+        .map((d) => d.deviceId)
+        .filter((id) => id.length > 0);
+      setWebCameraIds(ids);
+    } catch {
+      // Keep last known list if enumeration fails transiently.
+    }
+
+    if (ids.length === 0) return;
+    if (ids.length === 1) {
+      setCameraFacing((current) => (current === 'front' ? 'back' : 'front'));
+      return;
+    }
+
+    const currentId = activeWebCameraId && ids.includes(activeWebCameraId)
+      ? activeWebCameraId
+      : ids[0];
+    const currentIdx = ids.indexOf(currentId);
+    const nextId = ids[(currentIdx + 1) % ids.length];
+    setActiveWebCameraId(nextId);
+    selectCamera(nextId);
+    config.set('selectedCameraId', nextId);
+  };
+
+  const onWebMountError = useCallback((message: string, attemptedDeviceId?: string | null): void => {
+    setCameraMountError(message);
+    if (Platform.OS !== 'web' || requestingWebPermission || switchingAfterMountError) return;
+
+    if (mountErrorTimerRef.current) {
+      clearTimeout(mountErrorTimerRef.current);
+      mountErrorTimerRef.current = null;
+    }
+
+    const failedId = attemptedDeviceId ?? activeWebCameraId;
+    const looksLikePermissionIssue = /denied|notallowed|permission/i.test(message);
+    const switchToNextCamera = () => {
+      if (webCameraIds.length <= 1) return;
+      const currentId = failedId && webCameraIds.includes(failedId)
+        ? failedId
+        : webCameraIds[0];
+      const nextPool = webCameraIds.filter((id) => id !== currentId && id !== skipNextFailedCameraId);
+      if (nextPool.length === 0) return;
+      const nextId = nextPool[0];
+      setSkipNextFailedCameraId(currentId);
+      setSwitchingAfterMountError(true);
+      setActiveWebCameraId(nextId);
+      selectCamera(nextId);
+      config.set('selectedCameraId', nextId);
+      setWebMountAttempt((n) => n + 1);
+      setTimeout(() => setSwitchingAfterMountError(false), 250);
+    };
+
+    if (!looksLikePermissionIssue) {
+      // Grace period: some cameras report transient mount errors while warming up.
+      mountErrorTimerRef.current = setTimeout(() => {
+        switchToNextCamera();
+        mountErrorTimerRef.current = null;
+      }, 500);
+      return;
+    }
+
+    setRequestingWebPermission(true);
+    void navigator.mediaDevices.getUserMedia({ audio: false, video: true })
+      .then((stream) => {
+        stream.getTracks().forEach((t) => t.stop());
+        // Permission granted now -> retry same selected camera first.
+        setWebMountAttempt((n) => n + 1);
+      })
+      .catch(() => {
+        // Still failing -> generic fallback to next available camera.
+        mountErrorTimerRef.current = setTimeout(() => {
+          switchToNextCamera();
+          mountErrorTimerRef.current = null;
+        }, 500);
+      })
+      .finally(() => {
+        setRequestingWebPermission(false);
+      });
+  }, [activeWebCameraId, config, requestingWebPermission, selectCamera, switchingAfterMountError, webCameraIds, skipNextFailedCameraId]);
 
   return (
     <SafeAreaView className="flex-1 w-full self-stretch bg-gradient-to-br from-[#2ECC71]/5 via-white dark:via-gray-900 to-[#2ECC71]/5">
@@ -102,20 +238,25 @@ export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
                       onError={(message) => setCameraMountError(message)}
                     />
                   ) : (
-                    <CameraView
+                    <WebCameraView
                       style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+                      deviceId={activeWebCameraId}
                       facing={cameraFacing}
                       mirror={cameraFacing === 'front'}
-                      active={state !== SessionState.PAUSED}
-                      onCameraReady={() => {
-                        setTimeout(() => {
-                          if (typeof document === 'undefined') return;
-                          const container = cameraContainerRef.current as unknown as HTMLElement | null;
-                          const videoEl = container?.querySelector?.('video') ?? document.querySelector('video');
-                          setCameraVideoElement(videoEl as HTMLVideoElement | null);
-                        }, 500);
+                      active={true}
+                      sessionKey={`${sessionId ?? ''}:${webMountAttempt}`}
+                      onVideoElement={(el) => {
+                        setCameraVideoElement(el);
                       }}
-                      onMountError={(event) => setCameraMountError(event.message)}
+                      onCameraReady={() => {
+                        if (mountErrorTimerRef.current) {
+                          clearTimeout(mountErrorTimerRef.current);
+                          mountErrorTimerRef.current = null;
+                        }
+                        setCameraMountError(null);
+                        setSkipNextFailedCameraId(null);
+                      }}
+                      onMountError={onWebMountError}
                     />
                   )}
                   <View className="absolute inset-0 bg-black/20" />
@@ -184,10 +325,7 @@ export function LiveTranslationScreen({ onBack }: { onBack: () => void }) {
               <TouchableOpacity
                 className={`h-12 w-12 items-center justify-center rounded-full border border-white/20 bg-black/60 ${shouldShowLiveCamera ? '' : 'opacity-50'}`}
                 disabled={!shouldShowLiveCamera}
-                onPress={() => {
-                  if (!shouldShowLiveCamera) return;
-                  setCameraFacing((current) => (current === 'front' ? 'back' : 'front'));
-                }}
+                onPress={() => { void switchCamera(); }}
               >
                 <SwitchCamera size={20} color="#fff" />
               </TouchableOpacity>


### PR DESCRIPTION
## What does this PR do?

Fixes web camera startup/switching instability in live sessions by improving camera selection lifecycle, startup timing, and mount-failure handling so sessions start reliably and camera loops remain consistent.

## Which package(s) does it touch?

- `sozia.client.ui` (`ui/screens/LiveTranslationScreen.tsx`, `ui/components/WebCameraView`)
- `sozia.client.device` (`device/DeviceManager.ts`, `device/DeviceEnumerator.ts`)
- `sozia.client.ui` controller (`ui/controller/SessionController.tsx`)
- `sozia.client.ui` dashboard permissions UX (`ui/screens/DashboardScreen.tsx`)

## How to test

1. On web, open app and go to dashboard.
2. Verify missing permissions show prompt and retry action.
3. Start session with webcam selected.
4. Confirm session starts when preview is already live.
5. In session, switch cameras repeatedly (at least 10+ presses).
6. Stop session and start again; repeat camera switching loop.
7. Verify laptop cam and webcam are both still reachable after repeated loops.
8. Verify no crash/error on websocket ready/init sequence.
9. Smoke test native path (if available): camera view still mounts and toggle works.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally