### PR TITLE
fix(video): fix Android landmark bridge rebroadcasting stale frames

### DIFF
--- a/__tests__/pipeline/video/NativeCameraView.helpers.test.ts
+++ b/__tests__/pipeline/video/NativeCameraView.helpers.test.ts
@@ -1,4 +1,4 @@
-import { normalizeLandmarkFrame } from '@/ui/components/NativeCameraView/helpers';
+import { normalizeLandmarkFrame, extractSeq, extractInferenceCompletedAt } from '@/ui/components/NativeCameraView/helpers';
 
 /** Build a valid raw landmark dict matching LandmarkFrame shape */
 const makeValidRaw = (overrides: Record<string, unknown> = {}): unknown => ({
@@ -105,5 +105,49 @@ describe('normalizeLandmarkFrame', () => {
   it('returns null when timestampMs is missing', () => {
     const raw = makeValidRaw({ timestampMs: undefined });
     expect(normalizeLandmarkFrame(raw)).toBeNull();
+  });
+});
+
+describe('extractSeq', () => {
+  it('returns 0 for null or non-object input', () => {
+    expect(extractSeq(null)).toBe(0);
+    expect(extractSeq('str')).toBe(0);
+    expect(extractSeq([])).toBe(0);
+  });
+
+  it('returns 0 when seq field is absent', () => {
+    expect(extractSeq({ foo: 'bar' })).toBe(0);
+  });
+
+  it('returns 0 when seq is not a positive number', () => {
+    expect(extractSeq({ seq: 0 })).toBe(0);
+    expect(extractSeq({ seq: -1 })).toBe(0);
+    expect(extractSeq({ seq: 'str' })).toBe(0);
+  });
+
+  it('returns the seq value when present and positive', () => {
+    expect(extractSeq({ seq: 42 })).toBe(42);
+  });
+});
+
+describe('extractInferenceCompletedAt', () => {
+  it('returns 0 for null or non-object input', () => {
+    expect(extractInferenceCompletedAt(null)).toBe(0);
+    expect(extractInferenceCompletedAt('str')).toBe(0);
+    expect(extractInferenceCompletedAt([])).toBe(0);
+  });
+
+  it('returns 0 when inferenceCompletedAtMs field is absent (legacy plugin)', () => {
+    expect(extractInferenceCompletedAt({ seq: 1, timestampMs: 100 })).toBe(0);
+  });
+
+  it('returns 0 when inferenceCompletedAtMs is not a positive number', () => {
+    expect(extractInferenceCompletedAt({ inferenceCompletedAtMs: 0 })).toBe(0);
+    expect(extractInferenceCompletedAt({ inferenceCompletedAtMs: -1 })).toBe(0);
+    expect(extractInferenceCompletedAt({ inferenceCompletedAtMs: 'str' })).toBe(0);
+  });
+
+  it('returns the inferenceCompletedAtMs value when present and positive', () => {
+    expect(extractInferenceCompletedAt({ inferenceCompletedAtMs: 1234567890 })).toBe(1234567890);
   });
 });

--- a/__tests__/pipeline/video/NativeLandmarkBridge.test.ts
+++ b/__tests__/pipeline/video/NativeLandmarkBridge.test.ts
@@ -13,46 +13,81 @@ const makeFrame = (overrides: Partial<LandmarkFrame> = {}): LandmarkFrame => ({
 
 describe('NativeLandmarkBridge', () => {
   beforeEach(() => {
-    NativeLandmarkBridge.setLatestFrame(null);
+    // setLatestFrame(null) resets both latestEntry and lastConsumedSeq.
+    NativeLandmarkBridge.setLatestFrame(null, 0);
     NativeLandmarkBridge.setModelLoaded(false);
   });
 
-  it('starts with null frame', () => {
-    expect(NativeLandmarkBridge.getLatestFrame()).toBeNull();
+  describe('consumeFreshFrame()', () => {
+    it('returns null when no frame has been set', () => {
+      expect(NativeLandmarkBridge.consumeFreshFrame()).toBeNull();
+    });
+
+    it('returns the frame on the first consume after a new seq', () => {
+      const frame = makeFrame({ timestampMs: 5000 });
+      NativeLandmarkBridge.setLatestFrame(frame, 1);
+      expect(NativeLandmarkBridge.consumeFreshFrame()).toBe(frame);
+    });
+
+    it('returns null on subsequent consumes with the same seq (dedup)', () => {
+      const frame = makeFrame({ timestampMs: 5000 });
+      NativeLandmarkBridge.setLatestFrame(frame, 1);
+      NativeLandmarkBridge.consumeFreshFrame();
+      expect(NativeLandmarkBridge.consumeFreshFrame()).toBeNull();
+    });
+
+    it('returns the new frame after seq advances', () => {
+      const first = makeFrame({ timestampMs: 100 });
+      const second = makeFrame({ timestampMs: 200 });
+      NativeLandmarkBridge.setLatestFrame(first, 1);
+      NativeLandmarkBridge.consumeFreshFrame();
+      NativeLandmarkBridge.setLatestFrame(second, 2);
+      expect(NativeLandmarkBridge.consumeFreshFrame()).toBe(second);
+    });
+
+    it('returns null after bridge is cleared with setLatestFrame(null)', () => {
+      NativeLandmarkBridge.setLatestFrame(makeFrame(), 1);
+      NativeLandmarkBridge.setLatestFrame(null, 0);
+      expect(NativeLandmarkBridge.consumeFreshFrame()).toBeNull();
+    });
+
+    it('returns frame again after clear and re-set even with seq=1', () => {
+      NativeLandmarkBridge.setLatestFrame(makeFrame(), 1);
+      NativeLandmarkBridge.consumeFreshFrame();
+      NativeLandmarkBridge.setLatestFrame(null, 0);
+      const fresh = makeFrame({ timestampMs: 999 });
+      NativeLandmarkBridge.setLatestFrame(fresh, 1);
+      expect(NativeLandmarkBridge.consumeFreshFrame()).toBe(fresh);
+    });
   });
 
-  it('starts with model not loaded', () => {
-    expect(NativeLandmarkBridge.isModelLoaded()).toBe(false);
+  describe('peekLatestFrame()', () => {
+    it('returns the current frame without advancing lastConsumedSeq', () => {
+      const frame = makeFrame({ timestampMs: 5000 });
+      NativeLandmarkBridge.setLatestFrame(frame, 1);
+      NativeLandmarkBridge.peekLatestFrame();
+      expect(NativeLandmarkBridge.consumeFreshFrame()).toBe(frame);
+    });
+
+    it('returns null when bridge is empty', () => {
+      expect(NativeLandmarkBridge.peekLatestFrame()).toBeNull();
+    });
   });
 
-  it('setLatestFrame stores frame and getLatestFrame retrieves it', () => {
-    const frame = makeFrame({ timestampMs: 5000 });
-    NativeLandmarkBridge.setLatestFrame(frame);
-    expect(NativeLandmarkBridge.getLatestFrame()).toBe(frame);
-  });
+  describe('model loaded flag', () => {
+    it('starts as false', () => {
+      expect(NativeLandmarkBridge.isModelLoaded()).toBe(false);
+    });
 
-  it('setLatestFrame(null) clears the stored frame', () => {
-    NativeLandmarkBridge.setLatestFrame(makeFrame());
-    NativeLandmarkBridge.setLatestFrame(null);
-    expect(NativeLandmarkBridge.getLatestFrame()).toBeNull();
-  });
+    it('reflects setModelLoaded(true)', () => {
+      NativeLandmarkBridge.setModelLoaded(true);
+      expect(NativeLandmarkBridge.isModelLoaded()).toBe(true);
+    });
 
-  it('setModelLoaded(true) makes isModelLoaded() return true', () => {
-    NativeLandmarkBridge.setModelLoaded(true);
-    expect(NativeLandmarkBridge.isModelLoaded()).toBe(true);
-  });
-
-  it('setModelLoaded(false) makes isModelLoaded() return false after true', () => {
-    NativeLandmarkBridge.setModelLoaded(true);
-    NativeLandmarkBridge.setModelLoaded(false);
-    expect(NativeLandmarkBridge.isModelLoaded()).toBe(false);
-  });
-
-  it('overwrites previous frame on successive setLatestFrame calls', () => {
-    const first = makeFrame({ timestampMs: 100 });
-    const second = makeFrame({ timestampMs: 200 });
-    NativeLandmarkBridge.setLatestFrame(first);
-    NativeLandmarkBridge.setLatestFrame(second);
-    expect(NativeLandmarkBridge.getLatestFrame()).toBe(second);
+    it('reflects setModelLoaded(false) after true', () => {
+      NativeLandmarkBridge.setModelLoaded(true);
+      NativeLandmarkBridge.setModelLoaded(false);
+      expect(NativeLandmarkBridge.isModelLoaded()).toBe(false);
+    });
   });
 });

--- a/__tests__/pipeline/video/NativeLandmarkBridge.test.ts
+++ b/__tests__/pipeline/video/NativeLandmarkBridge.test.ts
@@ -23,50 +23,59 @@ describe('NativeLandmarkBridge', () => {
       expect(NativeLandmarkBridge.consumeFreshFrame()).toBeNull();
     });
 
-    it('returns the frame on the first consume after a new seq', () => {
+    it('returns the entry on the first consume after a new seq', () => {
+      const frame = makeFrame({ timestampMs: 5000 });
+      NativeLandmarkBridge.setLatestFrame(frame, 1, 5100);
+      const entry = NativeLandmarkBridge.consumeFreshFrame();
+      expect(entry?.frame).toBe(frame);
+      expect(entry?.inferenceCompletedAtMs).toBe(5100);
+      expect(entry?.seq).toBe(1);
+    });
+
+    it('falls back to frame.timestampMs when inferenceCompletedAtMs is omitted', () => {
       const frame = makeFrame({ timestampMs: 5000 });
       NativeLandmarkBridge.setLatestFrame(frame, 1);
-      expect(NativeLandmarkBridge.consumeFreshFrame()).toBe(frame);
+      expect(NativeLandmarkBridge.consumeFreshFrame()?.inferenceCompletedAtMs).toBe(5000);
     });
 
     it('returns null on subsequent consumes with the same seq (dedup)', () => {
       const frame = makeFrame({ timestampMs: 5000 });
-      NativeLandmarkBridge.setLatestFrame(frame, 1);
+      NativeLandmarkBridge.setLatestFrame(frame, 1, 5100);
       NativeLandmarkBridge.consumeFreshFrame();
       expect(NativeLandmarkBridge.consumeFreshFrame()).toBeNull();
     });
 
-    it('returns the new frame after seq advances', () => {
+    it('returns the new entry after seq advances', () => {
       const first = makeFrame({ timestampMs: 100 });
       const second = makeFrame({ timestampMs: 200 });
-      NativeLandmarkBridge.setLatestFrame(first, 1);
+      NativeLandmarkBridge.setLatestFrame(first, 1, 150);
       NativeLandmarkBridge.consumeFreshFrame();
-      NativeLandmarkBridge.setLatestFrame(second, 2);
-      expect(NativeLandmarkBridge.consumeFreshFrame()).toBe(second);
+      NativeLandmarkBridge.setLatestFrame(second, 2, 250);
+      expect(NativeLandmarkBridge.consumeFreshFrame()?.frame).toBe(second);
     });
 
     it('returns null after bridge is cleared with setLatestFrame(null)', () => {
-      NativeLandmarkBridge.setLatestFrame(makeFrame(), 1);
+      NativeLandmarkBridge.setLatestFrame(makeFrame(), 1, 100);
       NativeLandmarkBridge.setLatestFrame(null, 0);
       expect(NativeLandmarkBridge.consumeFreshFrame()).toBeNull();
     });
 
-    it('returns frame again after clear and re-set even with seq=1', () => {
-      NativeLandmarkBridge.setLatestFrame(makeFrame(), 1);
+    it('returns entry again after clear and re-set even with seq=1', () => {
+      NativeLandmarkBridge.setLatestFrame(makeFrame(), 1, 100);
       NativeLandmarkBridge.consumeFreshFrame();
       NativeLandmarkBridge.setLatestFrame(null, 0);
       const fresh = makeFrame({ timestampMs: 999 });
-      NativeLandmarkBridge.setLatestFrame(fresh, 1);
-      expect(NativeLandmarkBridge.consumeFreshFrame()).toBe(fresh);
+      NativeLandmarkBridge.setLatestFrame(fresh, 1, 1000);
+      expect(NativeLandmarkBridge.consumeFreshFrame()?.frame).toBe(fresh);
     });
   });
 
   describe('peekLatestFrame()', () => {
     it('returns the current frame without advancing lastConsumedSeq', () => {
       const frame = makeFrame({ timestampMs: 5000 });
-      NativeLandmarkBridge.setLatestFrame(frame, 1);
+      NativeLandmarkBridge.setLatestFrame(frame, 1, 5100);
       NativeLandmarkBridge.peekLatestFrame();
-      expect(NativeLandmarkBridge.consumeFreshFrame()).toBe(frame);
+      expect(NativeLandmarkBridge.consumeFreshFrame()?.frame).toBe(frame);
     });
 
     it('returns null when bridge is empty', () => {

--- a/__tests__/pipeline/video/NativeMediaPipeLandmarkBackend.test.ts
+++ b/__tests__/pipeline/video/NativeMediaPipeLandmarkBackend.test.ts
@@ -43,13 +43,13 @@ describe('NativeMediaPipeLandmarkBackend', () => {
 
     it('returns the frame on first extract after a new seq', () => {
       const frame = makeFrame();
-      NativeLandmarkBridge.setLatestFrame(frame, 1);
+      NativeLandmarkBridge.setLatestFrame(frame, 1, Date.now());
       expect(backend.extract(makeRawInput())).toBe(frame);
     });
 
     it('returns null on the second extract call with the same seq (dedup)', () => {
       const frame = makeFrame();
-      NativeLandmarkBridge.setLatestFrame(frame, 1);
+      NativeLandmarkBridge.setLatestFrame(frame, 1, Date.now());
       backend.extract(makeRawInput());
       expect(backend.extract(makeRawInput())).toBeNull();
     });
@@ -57,30 +57,38 @@ describe('NativeMediaPipeLandmarkBackend', () => {
     it('returns the new frame after seq advances', () => {
       const first = makeFrame({ timestampMs: Date.now() });
       const second = makeFrame({ timestampMs: Date.now() });
-      NativeLandmarkBridge.setLatestFrame(first, 1);
+      NativeLandmarkBridge.setLatestFrame(first, 1, Date.now());
       backend.extract(makeRawInput());
-      NativeLandmarkBridge.setLatestFrame(second, 2);
+      NativeLandmarkBridge.setLatestFrame(second, 2, Date.now());
       expect(backend.extract(makeRawInput())).toBe(second);
     });
 
     it('returns null after bridge is cleared', () => {
-      NativeLandmarkBridge.setLatestFrame(makeFrame(), 1);
+      NativeLandmarkBridge.setLatestFrame(makeFrame(), 1, Date.now());
       NativeLandmarkBridge.setLatestFrame(null, 0);
       expect(backend.extract(makeRawInput())).toBeNull();
     });
   });
 
   describe('extract() — staleness guard', () => {
-    it('returns null for a frame whose timestampMs is too old', () => {
+    it('returns null for a frame whose inferenceCompletedAtMs is too old', () => {
       // Default targetFps=30 → intervalMs≈33 → threshold = 33 * 3 = ~100 ms
-      const staleFrame = makeFrame({ timestampMs: Date.now() - 500 });
-      NativeLandmarkBridge.setLatestFrame(staleFrame, 1);
+      const frame = makeFrame({ timestampMs: Date.now() - 1000 });
+      NativeLandmarkBridge.setLatestFrame(frame, 1, Date.now() - 500);
       expect(backend.extract(makeRawInput())).toBeNull();
+    });
+
+    it('returns a frame whose inference completed recently even if capture time is older', () => {
+      // Simulates the real-world case: capture happened 150 ms ago (before inference
+      // started), but inference just completed — the frame should pass the guard.
+      const frame = makeFrame({ timestampMs: Date.now() - 150 });
+      NativeLandmarkBridge.setLatestFrame(frame, 1, Date.now() - 10);
+      expect(backend.extract(makeRawInput())).toBe(frame);
     });
 
     it('returns a recent frame', () => {
       const freshFrame = makeFrame({ timestampMs: Date.now() - 10 });
-      NativeLandmarkBridge.setLatestFrame(freshFrame, 1);
+      NativeLandmarkBridge.setLatestFrame(freshFrame, 1, Date.now() - 5);
       expect(backend.extract(makeRawInput())).toBe(freshFrame);
     });
   });

--- a/__tests__/pipeline/video/NativeMediaPipeLandmarkBackend.test.ts
+++ b/__tests__/pipeline/video/NativeMediaPipeLandmarkBackend.test.ts
@@ -5,7 +5,7 @@ import type { RawVideoFrame } from '@/pipeline/video/LandmarkExtractor';
 
 const makeFrame = (overrides: Partial<LandmarkFrame> = {}): LandmarkFrame => ({
   sessionId: 'test-session',
-  timestampMs: 1000,
+  timestampMs: Date.now(),
   faceLandmarks: [[0.1, 0.2, 0.3]],
   leftHandLandmarks: null,
   rightHandLandmarks: null,
@@ -14,7 +14,7 @@ const makeFrame = (overrides: Partial<LandmarkFrame> = {}): LandmarkFrame => ({
 });
 
 const makeRawInput = (overrides: Partial<RawVideoFrame> = {}): RawVideoFrame => ({
-  timestampMs: 1000,
+  timestampMs: Date.now(),
   width: 640,
   height: 480,
   data: null,
@@ -25,42 +25,63 @@ describe('NativeMediaPipeLandmarkBackend', () => {
   let backend: NativeMediaPipeLandmarkBackend;
 
   beforeEach(() => {
-    NativeLandmarkBridge.setLatestFrame(null);
+    NativeLandmarkBridge.setLatestFrame(null, 0);
     NativeLandmarkBridge.setModelLoaded(false);
     backend = new NativeMediaPipeLandmarkBackend();
   });
 
   describe('isReady()', () => {
-    it('always returns true regardless of bridge model state', () => {
-      // Native models load asynchronously; the session starts immediately
-      // and the frame processor returns null frames until models warm up.
+    it('always returns true — native models warm up in the background', () => {
       expect(backend.isReady()).toBe(true);
     });
   });
 
-  describe('extract()', () => {
+  describe('extract() — deduplication', () => {
     it('returns null when bridge has no frame', () => {
       expect(backend.extract(makeRawInput())).toBeNull();
     });
 
-    it('returns the frame stored in the bridge', () => {
-      const frame = makeFrame({ timestampMs: 9999 });
-      NativeLandmarkBridge.setLatestFrame(frame);
+    it('returns the frame on first extract after a new seq', () => {
+      const frame = makeFrame();
+      NativeLandmarkBridge.setLatestFrame(frame, 1);
       expect(backend.extract(makeRawInput())).toBe(frame);
     });
 
-    it('returns updated frame after bridge is overwritten', () => {
-      const first = makeFrame({ timestampMs: 100 });
-      const second = makeFrame({ timestampMs: 200 });
-      NativeLandmarkBridge.setLatestFrame(first);
-      NativeLandmarkBridge.setLatestFrame(second);
+    it('returns null on the second extract call with the same seq (dedup)', () => {
+      const frame = makeFrame();
+      NativeLandmarkBridge.setLatestFrame(frame, 1);
+      backend.extract(makeRawInput());
+      expect(backend.extract(makeRawInput())).toBeNull();
+    });
+
+    it('returns the new frame after seq advances', () => {
+      const first = makeFrame({ timestampMs: Date.now() });
+      const second = makeFrame({ timestampMs: Date.now() });
+      NativeLandmarkBridge.setLatestFrame(first, 1);
+      backend.extract(makeRawInput());
+      NativeLandmarkBridge.setLatestFrame(second, 2);
       expect(backend.extract(makeRawInput())).toBe(second);
     });
 
     it('returns null after bridge is cleared', () => {
-      NativeLandmarkBridge.setLatestFrame(makeFrame());
-      NativeLandmarkBridge.setLatestFrame(null);
+      NativeLandmarkBridge.setLatestFrame(makeFrame(), 1);
+      NativeLandmarkBridge.setLatestFrame(null, 0);
       expect(backend.extract(makeRawInput())).toBeNull();
+    });
+  });
+
+  describe('extract() — staleness guard', () => {
+    it('returns null for a frame whose timestampMs is too old', () => {
+      // Default targetFps=30 → intervalMs≈33 → threshold = 33 * 3 = ~100 ms
+      const staleFrame = makeFrame({ timestampMs: Date.now() - 500 });
+      NativeLandmarkBridge.setLatestFrame(staleFrame, 1);
+      expect(backend.extract(makeRawInput())).toBeNull();
+    });
+
+    it('returns a recent frame', () => {
+      const freshFrame = makeFrame({ timestampMs: Date.now() - 10 });
+      NativeLandmarkBridge.setLatestFrame(freshFrame, 1);
+      expect(backend.extract(makeRawInput())).toBe(freshFrame);
     });
   });
 });

--- a/modules/sozia-mediapipe/android/src/main/java/com/sozia/mediapipe/SoziaMediaPipeHolistic.kt
+++ b/modules/sozia-mediapipe/android/src/main/java/com/sozia/mediapipe/SoziaMediaPipeHolistic.kt
@@ -82,12 +82,14 @@ class SoziaMediaPipeHolistic(private val context: Context) {
         val poseResult = poseLandmarker?.detectForVideo(image, timestampMs) ?: return null
 
         val allFace: List<NormalizedLandmark>? = faceResult.faceLandmarks().firstOrNull()
+        // Always emit exactly 83 entries; zero-fill any index beyond the mesh size.
+        // Matches the web backend convention and prevents server validation errors on partial occlusion.
         val faceLandmarks: List<List<Float>>? = if (allFace != null) {
-            FACE_INDICES.toList().mapNotNull { idx: Int ->
+            FACE_INDICES.toList().map { idx: Int ->
                 if (idx < allFace.size) {
                     val lm: NormalizedLandmark = allFace[idx]
                     listOf(lm.x(), lm.y(), lm.z())
-                } else null
+                } else listOf(0f, 0f, 0f)
             }
         } else null
 

--- a/modules/sozia-mediapipe/android/src/main/java/com/sozia/mediapipe/SoziaMediaPipePlugin.kt
+++ b/modules/sozia-mediapipe/android/src/main/java/com/sozia/mediapipe/SoziaMediaPipePlugin.kt
@@ -92,8 +92,9 @@ class SoziaMediaPipePlugin(private val proxy: VisionCameraProxy, options: Map<St
                 val image = BitmapImageBuilder(bitmap).build()
                 val result = holistic.detect(image, ts)
                 if (result != null) {
+                    val completedAtMs = System.currentTimeMillis()
                     val seq = frameSeq.incrementAndGet()
-                    pendingResult.set(buildWritableMap(result, ts, sessionId, seq))
+                    pendingResult.set(buildWritableMap(result, ts, completedAtMs, sessionId, seq))
                 }
             } catch (_: Exception) {
             } finally {
@@ -184,17 +185,19 @@ class SoziaMediaPipePlugin(private val proxy: VisionCameraProxy, options: Map<St
     private fun buildWritableMap(
         result: SoziaMediaPipeHolistic.LandmarkResult,
         ts: Long,
+        completedAtMs: Long,
         sessionId: String,
         seq: Long,
     ): HashMap<String, Any?> {
         return hashMapOf(
-            "sessionId"          to sessionId,
-            "timestampMs"        to ts.toDouble(),
-            "seq"                to seq.toDouble(),
-            "faceLandmarks"      to toLandmarkList(result.faceLandmarks),
-            "leftHandLandmarks"  to toLandmarkList(result.leftHandLandmarks),
-            "rightHandLandmarks" to toLandmarkList(result.rightHandLandmarks),
-            "poseLandmarks"      to toLandmarkList(result.poseLandmarks)
+            "sessionId"              to sessionId,
+            "timestampMs"            to ts.toDouble(),
+            "inferenceCompletedAtMs" to completedAtMs.toDouble(),
+            "seq"                    to seq.toDouble(),
+            "faceLandmarks"          to toLandmarkList(result.faceLandmarks),
+            "leftHandLandmarks"      to toLandmarkList(result.leftHandLandmarks),
+            "rightHandLandmarks"     to toLandmarkList(result.rightHandLandmarks),
+            "poseLandmarks"          to toLandmarkList(result.poseLandmarks)
         )
     }
 

--- a/modules/sozia-mediapipe/android/src/main/java/com/sozia/mediapipe/SoziaMediaPipePlugin.kt
+++ b/modules/sozia-mediapipe/android/src/main/java/com/sozia/mediapipe/SoziaMediaPipePlugin.kt
@@ -51,8 +51,12 @@ class SoziaMediaPipePlugin(private val proxy: VisionCameraProxy, options: Map<St
     // Camera thread sets false → true before submitting; inference thread resets on finish.
     private val inferenceBusy = AtomicBoolean(false)
 
-    // Latest result produced by the inference thread; drained by the camera thread.
+    // Latest result produced by the inference thread; read (not cleared) by the camera thread.
+    // JS-side NativeLandmarkBridge deduplicates via the seq field.
     private val pendingResult = AtomicReference<HashMap<String, Any?>?>(null)
+
+    // Monotonically increasing counter stamped on each completed inference result.
+    private val frameSeq = java.util.concurrent.atomic.AtomicLong(0L)
 
     // Double-buffered output bitmaps: camera thread always writes to the idle slot
     // while the inference thread reads from the active slot.
@@ -66,8 +70,8 @@ class SoziaMediaPipePlugin(private val proxy: VisionCameraProxy, options: Map<St
     private var reusableV: ByteArray? = null
 
     override fun callback(frame: Frame, arguments: Map<String, Any>?): Any? {
-        // Return the most recent inference result (null if inference is still running).
-        val toReturn = pendingResult.getAndSet(null)
+        // Peek at the latest result without clearing — JS bridge deduplicates by seq.
+        val toReturn = pendingResult.get()
 
         val mediaImage = frame.image ?: return toReturn
 
@@ -87,7 +91,10 @@ class SoziaMediaPipePlugin(private val proxy: VisionCameraProxy, options: Map<St
             try {
                 val image = BitmapImageBuilder(bitmap).build()
                 val result = holistic.detect(image, ts)
-                if (result != null) pendingResult.set(buildWritableMap(result, ts, sessionId))
+                if (result != null) {
+                    val seq = frameSeq.incrementAndGet()
+                    pendingResult.set(buildWritableMap(result, ts, sessionId, seq))
+                }
             } catch (_: Exception) {
             } finally {
                 inferenceBusy.set(false)
@@ -177,11 +184,13 @@ class SoziaMediaPipePlugin(private val proxy: VisionCameraProxy, options: Map<St
     private fun buildWritableMap(
         result: SoziaMediaPipeHolistic.LandmarkResult,
         ts: Long,
-        sessionId: String
+        sessionId: String,
+        seq: Long,
     ): HashMap<String, Any?> {
         return hashMapOf(
             "sessionId"          to sessionId,
             "timestampMs"        to ts.toDouble(),
+            "seq"                to seq.toDouble(),
             "faceLandmarks"      to toLandmarkList(result.faceLandmarks),
             "leftHandLandmarks"  to toLandmarkList(result.leftHandLandmarks),
             "rightHandLandmarks" to toLandmarkList(result.rightHandLandmarks),

--- a/sozia/client/pipeline/video/NativeLandmarkBridge.ts
+++ b/sozia/client/pipeline/video/NativeLandmarkBridge.ts
@@ -5,19 +5,43 @@ import type { LandmarkFrame } from '@common/models';
  * and the VideoPipeline setInterval polling loop.
  *
  * The frame processor calls setLatestFrame() from the JS thread (via runOnJS)
- * after native inference completes. VideoPipeline polls getLatestFrame() at 30 fps.
+ * after native inference completes. VideoPipeline polls consumeFreshFrame() at 30 fps.
+ *
+ * consumeFreshFrame() returns a frame only when its seq has advanced since the last
+ * consumption, preventing VideoPipeline from re-broadcasting a stale inference result
+ * across multiple poll ticks.
  */
 
-let latestFrame: LandmarkFrame | null = null;
+type BridgeEntry = { frame: LandmarkFrame; seq: number } | null;
+
+let latestEntry: BridgeEntry = null;
+let lastConsumedSeq = -1;
 let modelLoaded = false;
 
 export const NativeLandmarkBridge = {
-  setLatestFrame(frame: LandmarkFrame | null): void {
-    latestFrame = frame;
+  setLatestFrame(frame: LandmarkFrame | null, seq: number): void {
+    if (frame === null) {
+      latestEntry = null;
+      lastConsumedSeq = -1;
+    } else {
+      latestEntry = { frame, seq };
+    }
   },
 
-  getLatestFrame(): LandmarkFrame | null {
-    return latestFrame;
+  /**
+   * Returns the latest frame only if its seq is newer than the last consumed seq.
+   * Returns null if the frame has already been consumed (stale) or no frame exists.
+   */
+  consumeFreshFrame(): LandmarkFrame | null {
+    if (latestEntry === null) return null;
+    if (latestEntry.seq <= lastConsumedSeq) return null;
+    lastConsumedSeq = latestEntry.seq;
+    return latestEntry.frame;
+  },
+
+  /** Read-only peek for health/debug — does not advance lastConsumedSeq. */
+  peekLatestFrame(): LandmarkFrame | null {
+    return latestEntry?.frame ?? null;
   },
 
   setModelLoaded(loaded: boolean): void {

--- a/sozia/client/pipeline/video/NativeLandmarkBridge.ts
+++ b/sozia/client/pipeline/video/NativeLandmarkBridge.ts
@@ -12,19 +12,42 @@ import type { LandmarkFrame } from '@common/models';
  * across multiple poll ticks.
  */
 
-type BridgeEntry = { frame: LandmarkFrame; seq: number } | null;
+export type BridgeFrame = {
+  frame: LandmarkFrame;
+  /**
+   * Wall-clock ms stamped in Kotlin immediately after holistic.detect returns,
+   * before the result is dispatched to JS. Used by the D1 staleness guard so
+   * the age is measured from when inference actually produced the result —
+   * not from the capture timestamp (which precedes the ~100 ms inference).
+   * Falls back to frame.timestampMs (capture time) when the native field is
+   * absent, preserving backwards compatibility with older plugin builds.
+   */
+  inferenceCompletedAtMs: number;
+  seq: number;
+};
+
+type BridgeEntry = BridgeFrame | null;
 
 let latestEntry: BridgeEntry = null;
 let lastConsumedSeq = -1;
 let modelLoaded = false;
 
 export const NativeLandmarkBridge = {
-  setLatestFrame(frame: LandmarkFrame | null, seq: number): void {
+  setLatestFrame(
+    frame: LandmarkFrame | null,
+    seq: number,
+    inferenceCompletedAtMs = 0,
+  ): void {
     if (frame === null) {
       latestEntry = null;
       lastConsumedSeq = -1;
     } else {
-      latestEntry = { frame, seq };
+      latestEntry = {
+        frame,
+        seq,
+        inferenceCompletedAtMs:
+          inferenceCompletedAtMs > 0 ? inferenceCompletedAtMs : frame.timestampMs,
+      };
     }
   },
 
@@ -32,11 +55,11 @@ export const NativeLandmarkBridge = {
    * Returns the latest frame only if its seq is newer than the last consumed seq.
    * Returns null if the frame has already been consumed (stale) or no frame exists.
    */
-  consumeFreshFrame(): LandmarkFrame | null {
+  consumeFreshFrame(): BridgeFrame | null {
     if (latestEntry === null) return null;
     if (latestEntry.seq <= lastConsumedSeq) return null;
     lastConsumedSeq = latestEntry.seq;
-    return latestEntry.frame;
+    return latestEntry;
   },
 
   /** Read-only peek for health/debug — does not advance lastConsumedSeq. */

--- a/sozia/client/pipeline/video/NativeMediaPipeLandmarkBackend.ts
+++ b/sozia/client/pipeline/video/NativeMediaPipeLandmarkBackend.ts
@@ -23,14 +23,17 @@ export class NativeMediaPipeLandmarkBackend implements LandmarkExtractionBackend
   }
 
   extract(_rawInput: RawVideoFrame): LandmarkFrame | null {
-    const frame = NativeLandmarkBridge.consumeFreshFrame();
-    if (frame === null) return null;
+    const entry = NativeLandmarkBridge.consumeFreshFrame();
+    if (entry === null) return null;
 
     // Guard against a frozen inference thread re-emitting an ancient frame.
-    const ageMs = Date.now() - frame.timestampMs;
+    // Age is measured from when inference completed, not capture time — native
+    // inference takes ~100 ms, which would otherwise exceed the staleness
+    // threshold and drop every fresh frame.
+    const ageMs = Date.now() - entry.inferenceCompletedAtMs;
     if (ageMs > this.targetIntervalMs * STALE_THRESHOLD_MULTIPLIER) return null;
 
-    return frame;
+    return entry.frame;
   }
 
   isReady(): boolean {

--- a/sozia/client/pipeline/video/NativeMediaPipeLandmarkBackend.ts
+++ b/sozia/client/pipeline/video/NativeMediaPipeLandmarkBackend.ts
@@ -2,6 +2,8 @@ import type { LandmarkFrame } from '@common/models';
 import type { LandmarkExtractionBackend, RawVideoFrame } from './LandmarkExtractor';
 import { NativeLandmarkBridge } from './NativeLandmarkBridge';
 
+const STALE_THRESHOLD_MULTIPLIER = 3;
+
 /**
  * Native MediaPipe landmark extraction backend.
  *
@@ -9,12 +11,26 @@ import { NativeLandmarkBridge } from './NativeLandmarkBridge';
  * The bridge is populated by the VisionCamera JSI frame processor plugin
  * (SoziaMediaPipePlugin) running inference on a dedicated native thread.
  *
- * This backend does NOT perform any inference itself — it is a thin reader
- * that decouples the VideoPipeline polling rate from the native inference rate.
+ * consumeFreshFrame() ensures each inference result is forwarded at most once,
+ * preventing the 30 Hz poll loop from re-broadcasting stale landmark frames
+ * to the server while the native thread is still busy.
  */
 export class NativeMediaPipeLandmarkBackend implements LandmarkExtractionBackend {
+  private readonly targetIntervalMs: number;
+
+  constructor(targetFps = 30) {
+    this.targetIntervalMs = 1000 / targetFps;
+  }
+
   extract(_rawInput: RawVideoFrame): LandmarkFrame | null {
-    return NativeLandmarkBridge.getLatestFrame();
+    const frame = NativeLandmarkBridge.consumeFreshFrame();
+    if (frame === null) return null;
+
+    // Guard against a frozen inference thread re-emitting an ancient frame.
+    const ageMs = Date.now() - frame.timestampMs;
+    if (ageMs > this.targetIntervalMs * STALE_THRESHOLD_MULTIPLIER) return null;
+
+    return frame;
   }
 
   isReady(): boolean {

--- a/sozia/client/pipeline/video/TrackingHealthMonitor.ts
+++ b/sozia/client/pipeline/video/TrackingHealthMonitor.ts
@@ -4,6 +4,7 @@ type RecentFrame = {
   timestampMs: number;
   detected: boolean;
   faceDetected: boolean;
+  inferenceActive: boolean;
 };
 
 /**
@@ -17,7 +18,13 @@ export class TrackingHealthMonitor {
     this.windowSizeMs = windowSizeMs;
   }
 
-  update(landmarks: LandmarkFrame | null): void {
+  /**
+   * @param landmarks - The emitted landmark frame (null when extraction produced nothing).
+   * @param inferenceActive - True when the backend produced a fresh inference result this tick.
+   *   On web this equals (landmarks !== null). On Android it's false during the ticks where
+   *   the bridge returned a stale/deduped frame, reflecting the true native inference rate.
+   */
+  update(landmarks: LandmarkFrame | null, inferenceActive = landmarks !== null): void {
     const ts =
       landmarks?.timestampMs ??
       (this.recentFrames.length > 0
@@ -27,6 +34,7 @@ export class TrackingHealthMonitor {
       timestampMs: ts,
       detected: landmarks !== null,
       faceDetected: landmarks !== null && landmarks.faceLandmarks !== null,
+      inferenceActive,
     };
 
     this.recentFrames.push(entry);
@@ -49,8 +57,10 @@ export class TrackingHealthMonitor {
     const first = this.recentFrames[0];
     const last = this.recentFrames[this.recentFrames.length - 1];
     const spanMs = Math.max(1, last.timestampMs - first.timestampMs);
-    const fps = Math.round((this.recentFrames.length / (spanMs / 1000)) * 10) / 10;
     const detectedCount = this.recentFrames.filter((f) => f.detected).length;
+    const activeCount = this.recentFrames.filter((f) => f.inferenceActive).length;
+    // fps reflects the true inference rate (fresh frames/sec), not the poll rate.
+    const fps = Math.round((activeCount / (spanMs / 1000)) * 10) / 10;
     const available = detectedCount / this.recentFrames.length > 0.5;
 
     return {

--- a/sozia/client/pipeline/video/VideoPipeline.ts
+++ b/sozia/client/pipeline/video/VideoPipeline.ts
@@ -117,7 +117,7 @@ export class VideoPipeline implements IVideoPipeline {
       const extracted = this.extractor.extract(rawFrame);
       const landmarkFrame = this.toLandmarkFrame(extracted, rawFrame.timestampMs);
 
-      this.healthMonitor.update(landmarkFrame);
+      this.healthMonitor.update(landmarkFrame, extracted !== null);
       if (landmarkFrame !== null) {
         this.transmissionManager?.sendFeatures(landmarkFrame);
       }
@@ -142,8 +142,11 @@ export class VideoPipeline implements IVideoPipeline {
     };
   }
 
-  private toLandmarkFrame(extracted: LandmarkFrame | null, timestampMs: number): LandmarkFrame | null {
+  private toLandmarkFrame(extracted: LandmarkFrame | null, pollTimestampMs: number): LandmarkFrame | null {
     if (!extracted) return null;
+    // Prefer the backend's capture timestamp over the JS poll time so the server
+    // receives a faithful capture instant rather than an arbitrary 30 Hz tick.
+    const timestampMs = extracted.timestampMs > 0 ? extracted.timestampMs : pollTimestampMs;
     return {
       sessionId: extracted.sessionId || this.sessionId,
       timestampMs,

--- a/sozia/client/ui/components/NativeCameraView/helpers.ts
+++ b/sozia/client/ui/components/NativeCameraView/helpers.ts
@@ -12,6 +12,16 @@ function isNumberArray(value: unknown): value is number[][] {
 }
 
 /**
+ * Extracts the monotonic seq counter from raw plugin output.
+ * Returns 0 if the field is absent (e.g., legacy plugin builds).
+ */
+export function extractSeq(raw: unknown): number {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return 0;
+  const seq = (raw as Record<string, unknown>)['seq'];
+  return typeof seq === 'number' && seq > 0 ? seq : 0;
+}
+
+/**
  * Validates and normalizes raw plugin output into a typed LandmarkFrame.
  *
  * Returns null if the input is malformed, missing required fields, or

--- a/sozia/client/ui/components/NativeCameraView/helpers.ts
+++ b/sozia/client/ui/components/NativeCameraView/helpers.ts
@@ -22,6 +22,18 @@ export function extractSeq(raw: unknown): number {
 }
 
 /**
+ * Extracts the native-side inference completion timestamp (ms, wall clock).
+ * Distinct from LandmarkFrame.timestampMs, which is the capture time set before
+ * inference starts. Used client-side for the D1 staleness guard so the threshold
+ * is measured from when the result was actually produced. Returns 0 if absent.
+ */
+export function extractInferenceCompletedAt(raw: unknown): number {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return 0;
+  const value = (raw as Record<string, unknown>)['inferenceCompletedAtMs'];
+  return typeof value === 'number' && value > 0 ? value : 0;
+}
+
+/**
  * Validates and normalizes raw plugin output into a typed LandmarkFrame.
  *
  * Returns null if the input is malformed, missing required fields, or

--- a/sozia/client/ui/components/NativeCameraView/index.tsx
+++ b/sozia/client/ui/components/NativeCameraView/index.tsx
@@ -1,13 +1,13 @@
 import React, { useRef, useEffect } from 'react';
 import { Platform, StyleProp, ViewStyle } from 'react-native';
 import type { LandmarkFrame } from '@common/models';
-import { normalizeLandmarkFrame, extractSeq } from './helpers';
+import { normalizeLandmarkFrame, extractSeq, extractInferenceCompletedAt } from './helpers';
 
 export interface NativeCameraViewProps {
   facing: 'front' | 'back';
   active: boolean;
   sessionId?: string;
-  onLandmarks: (frame: LandmarkFrame | null, seq?: number) => void;
+  onLandmarks: (frame: LandmarkFrame | null, seq?: number, inferenceCompletedAtMs?: number) => void;
   onError?: (message: string) => void;
   style?: StyleProp<ViewStyle>;
 }
@@ -44,7 +44,11 @@ if (Platform.OS !== 'web') {
 
     const dispatchLandmarks = useRunOnJS(
       (raw: unknown) => {
-        onLandmarksRef.current(normalizeLandmarkFrame(raw), extractSeq(raw));
+        onLandmarksRef.current(
+          normalizeLandmarkFrame(raw),
+          extractSeq(raw),
+          extractInferenceCompletedAt(raw),
+        );
       },
       [],
     );

--- a/sozia/client/ui/components/NativeCameraView/index.tsx
+++ b/sozia/client/ui/components/NativeCameraView/index.tsx
@@ -1,13 +1,13 @@
 import React, { useRef, useEffect } from 'react';
 import { Platform, StyleProp, ViewStyle } from 'react-native';
 import type { LandmarkFrame } from '@common/models';
-import { normalizeLandmarkFrame } from './helpers';
+import { normalizeLandmarkFrame, extractSeq } from './helpers';
 
 export interface NativeCameraViewProps {
   facing: 'front' | 'back';
   active: boolean;
   sessionId?: string;
-  onLandmarks: (frame: LandmarkFrame | null) => void;
+  onLandmarks: (frame: LandmarkFrame | null, seq?: number) => void;
   onError?: (message: string) => void;
   style?: StyleProp<ViewStyle>;
 }
@@ -44,7 +44,7 @@ if (Platform.OS !== 'web') {
 
     const dispatchLandmarks = useRunOnJS(
       (raw: unknown) => {
-        onLandmarksRef.current(normalizeLandmarkFrame(raw));
+        onLandmarksRef.current(normalizeLandmarkFrame(raw), extractSeq(raw));
       },
       [],
     );

--- a/sozia/client/ui/controller/SessionController.tsx
+++ b/sozia/client/ui/controller/SessionController.tsx
@@ -38,7 +38,7 @@ export type SessionControllerValue = {
   selectMicrophone: (id: string) => void;
   selectCamera: (id: string) => void;
   setCameraVideoElement: (el: HTMLVideoElement | null) => void;
-  setNativeLandmarks: (frame: LandmarkFrame | null, seq?: number) => void;
+  setNativeLandmarks: (frame: LandmarkFrame | null, seq?: number, inferenceCompletedAtMs?: number) => void;
 };
 
 const SessionControllerContext = createContext<SessionControllerValue | null>(null);
@@ -163,8 +163,8 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
     []
   );
 
-  const setNativeLandmarks = useCallback((frame: LandmarkFrame | null, seq = 0) => {
-    NativeLandmarkBridge.setLatestFrame(frame, seq);
+  const setNativeLandmarks = useCallback((frame: LandmarkFrame | null, seq = 0, inferenceCompletedAtMs = 0) => {
+    NativeLandmarkBridge.setLatestFrame(frame, seq, inferenceCompletedAtMs);
   }, []);
 
   const startSession = useCallback(async (path: ModalityPath) => {

--- a/sozia/client/ui/controller/SessionController.tsx
+++ b/sozia/client/ui/controller/SessionController.tsx
@@ -38,7 +38,7 @@ export type SessionControllerValue = {
   selectMicrophone: (id: string) => void;
   selectCamera: (id: string) => void;
   setCameraVideoElement: (el: HTMLVideoElement | null) => void;
-  setNativeLandmarks: (frame: LandmarkFrame | null) => void;
+  setNativeLandmarks: (frame: LandmarkFrame | null, seq?: number) => void;
 };
 
 const SessionControllerContext = createContext<SessionControllerValue | null>(null);
@@ -163,8 +163,8 @@ export function SessionControllerProvider({ children }: { children: React.ReactN
     []
   );
 
-  const setNativeLandmarks = useCallback((frame: LandmarkFrame | null) => {
-    NativeLandmarkBridge.setLatestFrame(frame);
+  const setNativeLandmarks = useCallback((frame: LandmarkFrame | null, seq = 0) => {
+    NativeLandmarkBridge.setLatestFrame(frame, seq);
   }, []);
 
   const startSession = useCallback(async (path: ModalityPath) => {


### PR DESCRIPTION
## What does this PR do?

Android TSL recognition was triggering ActivityDetector on ~25% of frames. `NativeMediaPipeLandmarkBackend.extract()` returned the same stale inference result on every 30 Hz poll while native inference ran at 7-10 Hz. Server wrist velocity was zero on duplicate frames, so they were marked inactive.

Also fixes a live bug: `SoziaMediaPipeHolistic` used `mapNotNull` on face indices and could emit fewer than 83 landmarks under occlusion, which the server rejects.

Closes #107

## Which package(s) does it touch?

`modules/sozia-mediapipe` (Android), `sozia/client/pipeline/video`

## How to test

Run a 30s TSL session on Android. ActivityDetector active-frame ratio should be above 60% during signing (was ~25%). `PipelineHealth.fps` should read ~10-12 Hz. Partially occluded face should not cause `ValueError` in server logs.

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated)
- [x] Tested locally