### PR TITLE
fix(landmark): emit pose visibility from both backends

### DIFF
--- a/modules/sozia-mediapipe/android/src/main/java/com/sozia/mediapipe/SoziaMediaPipeHolistic.kt
+++ b/modules/sozia-mediapipe/android/src/main/java/com/sozia/mediapipe/SoziaMediaPipeHolistic.kt
@@ -109,7 +109,7 @@ class SoziaMediaPipeHolistic(private val context: Context) {
 
         val posePoints: List<NormalizedLandmark>? = poseResult.landmarks().firstOrNull()
         val poseLandmarks: List<List<Float>>? = posePoints?.map { lm: NormalizedLandmark ->
-            listOf(lm.x(), lm.y(), lm.z())
+            listOf(lm.x(), lm.y(), lm.z(), lm.visibility() ?: 1.0f)
         }
 
         return LandmarkResult(faceLandmarks, leftHand, rightHand, poseLandmarks)

--- a/modules/sozia-mediapipe/android/src/main/java/com/sozia/mediapipe/SoziaMediaPipeHolistic.kt
+++ b/modules/sozia-mediapipe/android/src/main/java/com/sozia/mediapipe/SoziaMediaPipeHolistic.kt
@@ -109,7 +109,7 @@ class SoziaMediaPipeHolistic(private val context: Context) {
 
         val posePoints: List<NormalizedLandmark>? = poseResult.landmarks().firstOrNull()
         val poseLandmarks: List<List<Float>>? = posePoints?.map { lm: NormalizedLandmark ->
-            listOf(lm.x(), lm.y(), lm.z(), lm.visibility() ?: 1.0f)
+            listOf(lm.x(), lm.y(), lm.z(), lm.visibility().orElse(1.0f))
         }
 
         return LandmarkResult(faceLandmarks, leftHand, rightHand, poseLandmarks)

--- a/sozia/client/pipeline/video/WebMediaPipeLandmarkBackend.ts
+++ b/sozia/client/pipeline/video/WebMediaPipeLandmarkBackend.ts
@@ -53,6 +53,13 @@ function toLandmarkArray(
   return landmarks.map((lm) => [lm.x, lm.y, lm.z]);
 }
 
+function toPoseLandmarkArray(
+  landmarks: Array<{ x: number; y: number; z: number; visibility: number }> | undefined,
+): number[][] | null {
+  if (!landmarks || landmarks.length === 0) return null;
+  return landmarks.map((lm) => [lm.x, lm.y, lm.z, lm.visibility]);
+}
+
 export class WebMediaPipeLandmarkBackend implements LandmarkExtractionBackend {
   private faceLandmarker: FaceLandmarker | null = null;
   private handLandmarker: HandLandmarker | null = null;
@@ -155,7 +162,7 @@ export class WebMediaPipeLandmarkBackend implements LandmarkExtractionBackend {
     }
 
     const poseLandmarks = poseResult.landmarks?.[0]
-      ? toLandmarkArray(poseResult.landmarks[0])
+      ? toPoseLandmarkArray(poseResult.landmarks[0])
       : null;
 
     if (!faceLandmarks && !leftHandLandmarks && !rightHandLandmarks && !poseLandmarks) {


### PR DESCRIPTION
## What does this PR do?

Pose landmarks now include the real MediaPipe visibility value as a fourth component. Both backends were emitting `[x, y, z]` only; the server was padding visibility to `1.0` on its end. After this change, actual per-point confidence from MediaPipe goes through the full pipeline.

Android uses `lm.visibility().orElse(1.0f)` because the Java SDK returns `Optional<Float>`. The web backend gets a new `toPoseLandmarkArray` helper that reads the `visibility` field already present on `PoseLandmarkerResult` landmarks.

Companion PR on sozia-server: `fix/pose-landmark-schema` (closes #64). Both should merge together.

Closes #111

## Which package(s) does it touch?

`modules/sozia-mediapipe` (Android), `sozia/client/pipeline/video` (web)

## How to test

Run a live session on both platforms. Server logs should show non-`1.0` visibility values on the sign path. On Android, confirm no `ValueError` from the server (which would fire if the 4th component was missing).

## Checklist
- [x] Follows commit convention (`<type>(<scope>): <description>`)
- [x] Added/updated tests (if applicable)
- [x] No sozia.common schema changes (or: both repos updated) — companion server PR is `fix/pose-landmark-schema`
- [x] Tested locally